### PR TITLE
refactor(vta-sdk)!: vetting wire types come from the published trust-tasks specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,36 @@ VP. Custom JSON-LD contexts for our shapes live under
 `https://openvtc.org/contexts/` — baked into crates at compile time via
 `include_str!` so verification works offline.
 
+## Trust Task wire types come from `trust_tasks_rs::specs`
+
+The Trust Task specifications in dtgwg-trust-tasks-tf are normative, and
+`trust-tasks-codegen` generates a Rust type for every payload and response in
+the registry, published by `trust-tasks-rs` under `trust_tasks_rs::specs`.
+
+- **Never hand-write a payload or response type for a task that has a generated
+  module** (`trust_tasks_rs::schema_index::schema_for` says whether it does).
+  Use the generated type. A crate wanting a shorter path re-exports it, as
+  `vta_sdk::protocols::vetting` does, and takes type URI constants from
+  `<Payload as trust_tasks_rs::Payload>::TYPE_URI`, not a literal.
+- **Behaviour stays hand-written and operates on the generated types**: signing,
+  verification, counting, and the rules JSON Schema cannot state (an event's
+  `endDate` against its `startDate`) as a check over the generated type — never
+  a parallel struct or a field-by-field mirror.
+- **Read received JSON against the schema before parsing it**
+  (`vta_sdk::protocols::vetting::read_checked`). Some generated constructors
+  normalise what they parse, so only the JSON shows what was sent.
+- **A specification change lands in dtgwg-trust-tasks-tf first** and reaches
+  this workspace through a `trust-tasks-rs` bump — never as a local edit to a
+  copied type.
+- A generated type is foreign, so `utoipa::ToSchema` cannot be derived on it.
+  Document a REST body with a wrapper in `vta_sdk::openapi`, whose schema is
+  rendered from the specification's own.
+
+`vta-sdk/tests/generated_wire_types_census.rs` enforces the first rule: it fails
+on a serde type whose doc summary names a generated task as its payload,
+request, response or body. So name the task in a wire type's summary. Its
+baseline lists the types that predate their generated modules, and only shrinks.
+
 ## Typestate discipline for verified wire forms
 
 Wire forms that require cryptographic verification (VPs, VCs, signed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10060,9 +10060,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.20.1"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91dcbc364465388522a8a8f9185ef676fa17f5ac4e58c61645e5820198a7efd6"
+checksum = "17cda83dbfa2a6e68b2784737f21f26dcb3119df4e4c0d5399f37e59693ccfcf"
 dependencies = [
  "chrono",
  "serde",
@@ -10074,9 +10074,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.20.1"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e704570542ff40c852e8fcb07e3e2ff27b8e2616c6a692a617240beb0154cf"
+checksum = "b5657b84e6f47db783619aa146c2781f3533f93f997e9c41f37fd5b54d8920e0"
 dependencies = [
  "affinidi-messaging-didcomm",
  "base64 0.22.1",
@@ -10090,9 +10090,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.20.0"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b957e9d2f574bb44ab02bd47c4b4835a1077d187fa533ee7e2c0a050bbaba6"
+checksum = "8002af0c794c56f4d2d9ee740592224ebdb76451d0412cff0054ed451808869e"
 dependencies = [
  "axum",
  "chrono",
@@ -10109,9 +10109,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.20.0"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71ccec02538ade2ff475d40152a869c11878ef0d6195719a682c989733262bd"
+checksum = "67b359d3cb88e1b684bd4c37058693d30a851fe2c6d47a47a24780340fc1af6c"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -10126,9 +10126,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dbddbfa65cacec94a8c6423fdde6bfd3236c1e2ac51fd6276c5f801682566f"
+checksum = "c2f308a570035bc810d285c264a202e267c553ec67a32dacbd79da8e304f7c89"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,12 +290,12 @@ aws-lc-rs = "1.16"
 # members are emitted and the schema has never heard of them. Same failure
 # shape as `adminScope` above, which is why the floor moves rather than the
 # feature being guarded.
-trust-tasks-rs = { version = "0.20.3", default-features = false, features = [
+trust-tasks-rs = { version = "0.20.4", default-features = false, features = [
   "validate",
   "all-specs",
 ] }
-trust-tasks-capability-client = "0.20"
-trust-tasks-https = { version = "0.20", default-features = false, features = ["server", "client", "jwt"] }
+trust-tasks-capability-client = "0.20.4"
+trust-tasks-https = { version = "0.20.4", default-features = false, features = ["server", "client", "jwt"] }
 # The DIDComm binding. Carries `ENVELOPE_TYPE` — the one `type` every
 # Trust-Task DIDComm message must use, with the `TrustTask<P>` as its body —
 # and the `pack_trust_task`/`unpack_trust_task` pair that enforce it.
@@ -306,8 +306,8 @@ trust-tasks-https = { version = "0.20", default-features = false, features = ["s
 # A conformant peer rejects that, silently, because "not an envelope" is
 # indistinguishable from "not addressed to me". One constant, from the crate
 # that defines it.
-trust-tasks-didcomm = { version = "0.20", default-features = false }
-trust-tasks-proof = { version = "0.20", default-features = false, features = ["affinidi"] }
+trust-tasks-didcomm = { version = "0.20.4", default-features = false }
+trust-tasks-proof = { version = "0.20.4", default-features = false, features = ["affinidi"] }
 
 # Axum extras (typed headers for Bearer auth)
 axum-extra = { version = "0.12", features = ["typed-header"] }

--- a/cnm-cli/src/vetting/bootstrap.rs
+++ b/cnm-cli/src/vetting/bootstrap.rs
@@ -214,15 +214,19 @@ pub(super) async fn run(
             outcomes.push(None);
             continue;
         };
-        let outcome = match vtc.grant_vetter(did, validity).await {
-            Ok(g) if g.created => GrantOutcome::Granted {
-                endorsement_id: g.grant.endorsement_id,
-            },
-            Ok(g) => GrantOutcome::AlreadyGranted {
-                endorsement_id: g.grant.endorsement_id,
-            },
-            Err(e) => GrantOutcome::Failed {
-                error: guidance(e, Op::Grant { member_did: did }).to_string(),
+        let payload = super::grant_payload(did, validity).map_err(|e| e.to_string());
+        let outcome = match payload {
+            Err(error) => GrantOutcome::Failed { error },
+            Ok(payload) => match vtc.grant_vetter(&payload).await {
+                Ok(g) if g.created => GrantOutcome::Granted {
+                    endorsement_id: g.grant.endorsement_id.into(),
+                },
+                Ok(g) => GrantOutcome::AlreadyGranted {
+                    endorsement_id: g.grant.endorsement_id.into(),
+                },
+                Err(e) => GrantOutcome::Failed {
+                    error: guidance(e, Op::Grant { member_did: did }).to_string(),
+                },
             },
         };
         outcomes.push(Some(outcome));

--- a/cnm-cli/src/vetting/mod.rs
+++ b/cnm-cli/src/vetting/mod.rs
@@ -34,9 +34,12 @@ use vta_cli_common::render::{
     print_full_list_title, print_json, print_widget,
 };
 use vta_sdk::client::VtaClient;
-use vtc_client::join_requests::CommunityBranding;
+use vtc_client::join_requests::manifest::v0_2::{
+    CommunityBranding, CommunityBrandingAccentColor, CommunityBrandingDisplayName,
+};
+use vtc_client::vetting::vetters::grant::v0_1 as grant_wire;
 use vtc_client::vetting::{
-    AutoGrantConfig, AutoGrantStatus, GrantOrigin, MAX_AUTO_GRANT_SWEEP_MINUTES,
+    AutoGrantConfig, AutoGrantStatus, CheckShape, GrantOrigin, MAX_AUTO_GRANT_SWEEP_MINUTES,
     MAX_VETTER_GRANT_VALIDITY_SECONDS, MIN_AUTO_GRANT_SWEEP_MINUTES,
     MIN_VETTER_GRANT_VALIDITY_SECONDS, VetterGrantRow,
 };
@@ -327,12 +330,29 @@ async fn cmd_vetters_list(vtc: &VtcClient) -> CliResult {
     Ok(())
 }
 
+/// The `vtc/vetting/vetters/grant/0.1` payload naming `member_did`.
+pub(crate) fn grant_payload(
+    member_did: &str,
+    validity_seconds: Option<u64>,
+) -> CliResult<grant_wire::Payload> {
+    let validity_seconds = validity_seconds
+        .map(i64::try_from)
+        .transpose()
+        .map_err(|_| "the grant validity is too large")?;
+    grant_wire::Payload::try_from(
+        grant_wire::Payload::builder()
+            .member_did(member_did)
+            .validity_seconds(validity_seconds),
+    )
+    .map_err(|e| format!("{member_did} cannot be named in a vetter grant: {e}").into())
+}
+
 async fn cmd_vetters_grant(vtc: &VtcClient, member_did: &str, validity: Option<&str>) -> CliResult {
     let validity_seconds = validity
         .map(|v| parse_grant_validity("--validity", v))
         .transpose()?;
     let result = vtc
-        .grant_vetter(member_did, validity_seconds)
+        .grant_vetter(&grant_payload(member_did, validity_seconds)?)
         .await
         .map_err(|e| guidance(e, Op::Grant { member_did }))?;
     let grant = &result.grant;
@@ -356,8 +376,8 @@ async fn cmd_vetters_grant(vtc: &VtcClient, member_did: &str, validity: Option<&
             );
         }
     }
-    println!("  Endorsement:  {}", grant.endorsement_id);
-    println!("  Credential:   {}", grant.credential_id);
+    println!("  Endorsement:  {}", grant.endorsement_id.as_str());
+    println!("  Credential:   {}", grant.credential_id.as_str());
     println!(
         "  Valid:        {} → {}",
         date(grant.valid_from),
@@ -366,7 +386,7 @@ async fn cmd_vetters_grant(vtc: &VtcClient, member_did: &str, validity: Option<&
     println!(
         "  {DIM}Withdraw it with `{} vetting vetters revoke {}`.{RESET}",
         bin_name(),
-        grant.endorsement_id
+        grant.endorsement_id.as_str()
     );
     Ok(())
 }
@@ -405,7 +425,7 @@ async fn cmd_vetters_resend(vtc: &VtcClient, member_did: &str) -> CliResult {
     println!(
         "{GREEN}✓{RESET} Handed credential {} to the community's messaging transport for \
          {member_did}.",
-        sent.credential_id
+        sent.credential_id.as_str()
     );
     println!("  Valid until:  {}", date(sent.valid_until));
     println!(
@@ -607,11 +627,17 @@ fn merged_branding(
             BrandingField::LogoUrl => current.logo_url = None,
         }
     }
-    if change.display_name.is_some() {
-        current.display_name = change.display_name;
+    if let Some(name) = change.display_name {
+        current.display_name = Some(
+            CommunityBrandingDisplayName::try_from(name)
+                .map_err(|e| format!("--display-name: {e}"))?,
+        );
     }
-    if change.accent_color.is_some() {
-        current.accent_color = change.accent_color;
+    if let Some(color) = change.accent_color {
+        current.accent_color = Some(
+            CommunityBrandingAccentColor::try_from(color)
+                .map_err(|e| format!("--accent-color must be #rrggbb: {e}"))?,
+        );
     }
     if change.logo_url.is_some() {
         current.logo_url = change.logo_url;
@@ -625,10 +651,16 @@ fn print_branding(branding: &CommunityBranding) -> CliResult {
         return Ok(());
     }
     let unset = format!("{DIM}(not set){RESET}");
-    let show = |v: &Option<String>| v.clone().unwrap_or_else(|| unset.clone());
-    println!("  Display name:  {}", show(&branding.display_name));
-    println!("  Accent colour: {}", show(&branding.accent_color));
-    println!("  Logo URL:      {}", show(&branding.logo_url));
+    let show = |v: Option<&str>| v.map_or_else(|| unset.clone(), str::to_owned);
+    println!(
+        "  Display name:  {}",
+        show(branding.display_name.as_ref().map(|v| v.as_str()))
+    );
+    println!(
+        "  Accent colour: {}",
+        show(branding.accent_color.as_ref().map(|v| v.as_str()))
+    );
+    println!("  Logo URL:      {}", show(branding.logo_url.as_deref()));
     if branding.display_name.is_none()
         && branding.accent_color.is_none()
         && branding.logo_url.is_none()
@@ -996,12 +1028,12 @@ mod tests {
 
     #[test]
     fn branding_set_merges_clears_and_refuses_a_contradiction() {
-        let current = CommunityBranding {
-            display_name: Some("Linux Kernel".into()),
-            accent_color: Some("#1a2b3c".into()),
-            logo_url: Some("https://kernel.example/logo.svg".into()),
-            ext: None,
-        };
+        let current: CommunityBranding = serde_json::from_value(json!({
+            "displayName": "Linux Kernel",
+            "accentColor": "#1a2b3c",
+            "logoUrl": "https://kernel.example/logo.svg",
+        }))
+        .unwrap();
         let merged = merged_branding(
             current.clone(),
             BrandingChange {
@@ -1011,9 +1043,26 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(merged.display_name.as_deref(), Some("Linux Kernel"));
-        assert_eq!(merged.accent_color.as_deref(), Some("#000000"));
+        assert_eq!(
+            merged.display_name.as_ref().map(|v| v.as_str()),
+            Some("Linux Kernel")
+        );
+        assert_eq!(
+            merged.accent_color.as_ref().map(|v| v.as_str()),
+            Some("#000000")
+        );
         assert!(merged.logo_url.is_none());
+
+        let err = merged_branding(
+            current.clone(),
+            BrandingChange {
+                accent_color: Some("red".into()),
+                ..BrandingChange::default()
+            },
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--accent-color"), "{err}");
 
         let err = merged_branding(
             current,

--- a/docs/03-vtc/vetting.md
+++ b/docs/03-vtc/vetting.md
@@ -6,8 +6,26 @@ before joining: each vetter checks who the applicant is and signs a
 presentation. This replaces a web of trust with evidence the community can
 count, without publishing who vouched for whom.
 
-Design: OpenVTC `docs/design/vetting-process.md`. Wire types and verification:
-`vta_sdk::protocols::vetting` and `vta_sdk::vetting`.
+Design: OpenVTC `docs/design/vetting-process.md`.
+
+**Wire types.** Every vetting Trust Task payload and response — `vetting/request`,
+`vetting/session` (with the Vetting Card), `vetting/decline`,
+`vtc/vetting/revoke-statement`, `vtc/vetting/vetters/{grant,profile,list,resend}`
+and `vtc/join-requests/manifest/0.2` (with `VettingRequirements` and
+`CommunityBranding`) — is the type generated from its published specification
+in dtgwg-trust-tasks-tf, shipped in `trust-tasks-rs` and re-exported from
+`vta_sdk::protocols::vetting` (the manifest from
+`vta_sdk::protocols::join_requests::manifest`). Nothing restates them; a change to
+a vetting wire shape is made in the specification and arrives with a
+`trust-tasks-rs` release. The community checks what it receives against the
+published schema before parsing it (`vta_sdk::protocols::vetting::read_checked`),
+then applies the rules a schema cannot state, such as an event's `endDate`
+against its `startDate`.
+
+What is not a Trust Task stays in `vta_sdk::protocols::vetting` as its own type:
+the Vetting Statement's endorsement body (`IdentityVettingEndorsement`, in the
+specification's vocabulary) and the admin REST bodies for grant rows and
+automatic grants. Signing, verification and counting are in `vta_sdk::vetting`.
 
 ## Setting it up
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -32,7 +32,6 @@ proof-verify = [
   "dep:affinidi-did-resolver-traits",
   "dep:affinidi-did-common",
   "dep:affinidi-secrets-resolver",
-  "dep:trust-tasks-rs",
 ]
 didcomm = [
   "dep:affinidi-tdk",
@@ -65,8 +64,6 @@ tsp = [
   # feature, which `affinidi-tdk/tsp` does not enable — flip it directly.
   "dep:affinidi-messaging-sdk",
   "affinidi-messaging-sdk/tsp",
-  # `TspPingSession` builds a `trust_tasks_rs::TrustTask` envelope.
-  "dep:trust-tasks-rs",
   "dep:affinidi-did-resolver-cache-sdk",
   "dep:affinidi-did-resolver-traits",
   "dep:affinidi-did-common",
@@ -104,10 +101,9 @@ client = [
   # `auth_di` — the canonical REST auth transport. The VTA requires an
   # *authenticated* sender on `/auth/*` (VTI #771), so the client signs an
   # `auth/authenticate/0.1` Trust Task with the holder key: the DI suite
-  # signs, `Secret` carries the key, `trust-tasks-rs` is the document shape.
+  # signs, `Secret` carries the key.
   "dep:affinidi-data-integrity",
   "dep:affinidi-secrets-resolver",
-  "dep:trust-tasks-rs",
   # didcomm 0.15 moved `PublicKeyAgreement` out of
   # `affinidi_messaging_didcomm::crypto` into `affinidi_crypto::jose`.
   # `didcomm_light::pack_anoncrypt` (gated on `client`) names that type,
@@ -210,14 +206,12 @@ provision-client = [
   "provision-integration",
   "session",
   "dep:tracing",
-  "dep:trust-tasks-rs",
 ]
 # Per-DID mediator ACL configuration on DIDComm connect.
-# Requires a live ATM (`session`) and the trust-tasks wire types (`trust-tasks-rs`).
+# Requires a live ATM (`session`).
 # Used by both VTA (after listener connects) and PNM (after DIDComm session opens).
 acl-setup = [
   "session",
-  "dep:trust-tasks-rs",
   "dep:sha2",
   "dep:tracing",
   "dep:tokio",
@@ -329,11 +323,12 @@ affinidi-crypto = { workspace = true, optional = true }
 affinidi-vc = { workspace = true, optional = true }
 affinidi-data-integrity = { workspace = true, optional = true }
 affinidi-secrets-resolver = { workspace = true, optional = true }
-# Trust Task document/proof types for the DI-signed REST auth path
-# (`provision_client::auth_rest`). Optional + gated on `provision-client` so the
-# published artifact stays slim for non-provisioning consumers; also present as
-# a dev-dependency for the always-on conformance tests below.
-trust-tasks-rs = { workspace = true, optional = true }
+# The Trust Task framework and the wire types generated from the published
+# specifications (`trust_tasks_rs::specs`). Required, not feature-gated: the
+# always-compiled `protocols` modules re-export the generated payload and
+# response types as this crate's wire layer, and check values against the
+# schemas those types embed (the workspace dependency enables `validate`).
+trust-tasks-rs = { workspace = true }
 # DTG credential construction for the Vetting Statement (`vetting` feature).
 dtg-credentials = { workspace = true, optional = true }
 # Bitstring status-list decoding for `vetting::status` (`vetting` feature).
@@ -390,11 +385,6 @@ required-features = ["sealed-transfer", "provision-integration"]
 tokio = { workspace = true }
 tempfile = "3"
 wiremock = "0.6"
-# Framework type-uri parser — used only by the trust-task URI
-# registry test (`every_uri_parses_as_framework_type_uri`) to pin
-# framework canonical-form conformance. Dev-only so the published
-# artifact stays slim.
-trust-tasks-rs = { workspace = true }
 # Examples need direct access to crypto primitives the SDK normally
 # encapsulates — pulled into dev-deps only so the published artifact
 # stays slim.

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -167,6 +167,10 @@ pub mod resolver;
 // just to import `protocol::services::validate_service_url`.
 pub mod protocol;
 pub mod protocols;
+// OpenAPI schemas for the published Trust Task types a service serves over
+// REST, rendered from the schemas the generated types embed.
+#[cfg(feature = "openapi")]
+pub mod openapi;
 #[cfg(feature = "provision-client")]
 pub mod provision_client;
 #[cfg(feature = "provision-integration")]

--- a/vta-sdk/src/openapi.rs
+++ b/vta-sdk/src/openapi.rs
@@ -1,0 +1,463 @@
+//! OpenAPI schemas for published Trust Task types a service serves over REST
+//! (feature `openapi`).
+//!
+//! A generated type is foreign to every crate that serves it, so `ToSchema`
+//! cannot be derived on it — and a local struct describing it would be exactly
+//! the hand-written copy the generated types exist to remove. The schema comes
+//! from the specification instead. Each type below wraps one generated type
+//! transparently — the JSON on the wire is the generated type's own — and
+//! documents it by rendering the JSON Schema that type embeds as OpenAPI
+//! components.
+//!
+//! A handler takes and returns `Json<Wrapper>`, and its `#[utoipa::path]` names
+//! the wrapper as the body, so the document describes what the specification
+//! publishes rather than what someone transcribed from it. A field of a local
+//! admin type can point at one with `#[schema(value_type = …)]`.
+//!
+//! ## Component names
+//!
+//! The task's slug and version, then the definition:
+//! `VtcVettingVettersListV0_1Payload`, `VtcVettingVettersListV0_1ListedVetter`.
+//! Two specifications that each define a `VetterEvent` cannot collide, and a
+//! reader can tell which specification a component came from.
+//!
+//! ## What the rendering carries
+//!
+//! Structure and bounds: types, members, `required`, `additionalProperties`,
+//! `oneOf`/`anyOf`/`allOf`, `enum`/`const`, `format`, patterns, lengths, item
+//! counts and numeric ranges. JSON Schema keywords utoipa's model has no field
+//! for — `dependentSchemas`, `dependentRequired`, `not`, `propertyNames` — are
+//! not rendered; a service enforces them at runtime through
+//! [`crate::protocols::vetting::CheckShape`].
+//!
+//! ## Exposing another type
+//!
+//! Add a line to the [`spec_types!`] table: the wrapper's name, the generated
+//! type, and — for a type that is a `$defs` entry of another type's schema rather
+//! than a payload or response itself — the carrier and the definition's name.
+
+use std::borrow::Cow;
+use std::ops::{Deref, DerefMut};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use utoipa::openapi::schema::{
+    AdditionalProperties, AllOfBuilder, AnyOfBuilder, ArrayBuilder, ObjectBuilder, OneOfBuilder,
+    Schema, SchemaFormat, SchemaType, Type,
+};
+use utoipa::openapi::{Ref, RefOr};
+
+use crate::protocols::vetting::vetters;
+use trust_tasks_rs::specs::vtc::join_requests::manifest;
+
+/// Transparent wrappers documenting generated types, one per line.
+macro_rules! spec_types {
+    ($(
+        $(#[$doc:meta])*
+        $name:ident($ty:ty) $(in $carrier:ty as $definition:literal)?;
+    )+) => {
+        $(
+            $(#[$doc])*
+            #[derive(Debug, Clone, Serialize, Deserialize)]
+            #[serde(transparent)]
+            pub struct $name(pub $ty);
+
+            impl $name {
+                /// The wrapped value.
+                pub fn into_inner(self) -> $ty {
+                    self.0
+                }
+            }
+
+            impl From<$ty> for $name {
+                fn from(value: $ty) -> Self {
+                    Self(value)
+                }
+            }
+
+            impl Deref for $name {
+                type Target = $ty;
+                fn deref(&self) -> &$ty {
+                    &self.0
+                }
+            }
+
+            impl DerefMut for $name {
+                fn deref_mut(&mut self) -> &mut $ty {
+                    &mut self.0
+                }
+            }
+
+            impl utoipa::PartialSchema for $name {
+                fn schema() -> RefOr<Schema> {
+                    spec_types!(@rendered $ty $(, $carrier, $definition)?).schema
+                }
+            }
+
+            impl utoipa::ToSchema for $name {
+                fn name() -> Cow<'static, str> {
+                    Cow::Owned(spec_types!(@rendered $ty $(, $carrier, $definition)?).name)
+                }
+
+                fn schemas(schemas: &mut Vec<(String, RefOr<Schema>)>) {
+                    schemas.extend(
+                        spec_types!(@rendered $ty $(, $carrier, $definition)?).definitions,
+                    );
+                }
+            }
+        )+
+    };
+    (@rendered $ty:ty) => {
+        rendered::<$ty>(None)
+    };
+    (@rendered $ty:ty, $carrier:ty, $definition:literal) => {
+        rendered::<$carrier>(Some($definition))
+    };
+}
+
+spec_types! {
+    /// `vtc/vetting/vetters/grant/0.1` payload.
+    VetterGrant01Payload(vetters::grant::v0_1::Payload);
+    /// `vtc/vetting/vetters/grant/0.1#response`.
+    VetterGrant01Response(vetters::grant::v0_1::Response);
+    /// `vtc/vetting/vetters/list/0.1` payload.
+    VetterList01Payload(vetters::list::v0_1::Payload);
+    /// `vtc/vetting/vetters/list/0.1#response`.
+    VetterList01Response(vetters::list::v0_1::Response);
+    /// `vtc/vetting/vetters/resend/0.1#response`.
+    VetterResend01Response(vetters::resend::v0_1::Response);
+    /// `vtc/vetting/vetters/profile/0.1`'s `VettingMethod`.
+    VetterProfile01VettingMethod(vetters::profile::v0_1::VettingMethod)
+        in vetters::profile::v0_1::Payload as "VettingMethod";
+    /// `vtc/join-requests/manifest/0.1#response`.
+    JoinManifest01Response(manifest::v0_1::Response);
+    /// `vtc/join-requests/manifest/0.2#response`.
+    JoinManifest02Response(manifest::v0_2::Response);
+    /// `vtc/join-requests/manifest/0.2`'s `VettingRequirements`.
+    JoinManifest02VettingRequirements(manifest::v0_2::VettingRequirements)
+        in manifest::v0_2::Response as "VettingRequirements";
+    /// `vtc/join-requests/manifest/0.2`'s `CommunityBranding` — also the body of a
+    /// VTC's `GET`/`PUT /v1/community/branding`.
+    JoinManifest02CommunityBranding(manifest::v0_2::CommunityBranding)
+        in manifest::v0_2::Response as "CommunityBranding";
+}
+
+/// One type's component, and every other definition of its schema, which the
+/// component may refer to.
+struct Rendered {
+    name: String,
+    schema: RefOr<Schema>,
+    definitions: Vec<(String, RefOr<Schema>)>,
+}
+
+/// Render the type `definition` names in `C`'s embedded schema — or, when it
+/// names none, `C` itself.
+fn rendered<C: trust_tasks_rs::Payload>(definition: Option<&str>) -> Rendered {
+    let prefix = component_prefix(C::TYPE_URI);
+    let schema: Value = C::PAYLOAD_SCHEMA
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or(Value::Bool(true));
+    let definitions = schema
+        .get("$defs")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+
+    // A named definition; else the definition a response schema's root refers
+    // to; else the root itself, which is a payload.
+    let own = definition.map(str::to_string).or_else(|| {
+        schema
+            .get("$ref")
+            .and_then(Value::as_str)
+            .and_then(|r| r.strip_prefix("#/$defs/"))
+            .map(str::to_string)
+    });
+    let (name, node) = match &own {
+        Some(definition) => (
+            format!("{prefix}{definition}"),
+            definitions
+                .get(definition)
+                .cloned()
+                .unwrap_or(Value::Bool(true)),
+        ),
+        None => (format!("{prefix}Payload"), schema.clone()),
+    };
+
+    Rendered {
+        name,
+        schema: convert(&node, &prefix),
+        definitions: definitions
+            .iter()
+            .filter(|(definition, _)| own.as_deref() != Some(definition.as_str()))
+            .map(|(definition, node)| (format!("{prefix}{definition}"), convert(node, &prefix)))
+            .collect(),
+    }
+}
+
+/// `https://trusttasks.org/spec/vtc/join-requests/manifest/0.2#response` →
+/// `VtcJoinRequestsManifestV0_2`.
+fn component_prefix(type_uri: &str) -> String {
+    let path = type_uri.split('#').next().unwrap_or(type_uri);
+    let path = path.split_once("/spec/").map_or(path, |(_, p)| p);
+    let mut segments: Vec<&str> = path.split('/').collect();
+    let version = segments.pop().unwrap_or_default();
+    let mut out = String::new();
+    for word in segments.iter().flat_map(|s| s.split('-')) {
+        let mut chars = word.chars();
+        if let Some(first) = chars.next() {
+            out.extend(first.to_uppercase());
+            out.push_str(chars.as_str());
+        }
+    }
+    out.push('V');
+    out.push_str(&version.replace('.', "_"));
+    out
+}
+
+fn convert(node: &Value, prefix: &str) -> RefOr<Schema> {
+    let Some(obj) = node.as_object() else {
+        // `true`: anything.
+        return RefOr::T(Schema::Object(
+            ObjectBuilder::new()
+                .schema_type(SchemaType::AnyValue)
+                .build(),
+        ));
+    };
+    let description = obj.get("description").and_then(Value::as_str);
+
+    if let Some(target) = obj.get("$ref").and_then(Value::as_str) {
+        let name = target
+            .strip_prefix("#/$defs/")
+            .map_or_else(|| target.to_string(), |d| format!("{prefix}{d}"));
+        return RefOr::Ref(Ref::from_schema_name(name));
+    }
+    if let Some(items) = obj.get("oneOf").and_then(Value::as_array) {
+        let builder = items
+            .iter()
+            .fold(OneOfBuilder::new().description(description), |b, item| {
+                b.item(convert(item, prefix))
+            });
+        return RefOr::T(Schema::OneOf(builder.build()));
+    }
+    if let Some(items) = obj.get("anyOf").and_then(Value::as_array) {
+        let builder = items
+            .iter()
+            .fold(AnyOfBuilder::new().description(description), |b, item| {
+                b.item(convert(item, prefix))
+            });
+        return RefOr::T(Schema::AnyOf(builder.build()));
+    }
+    if let Some(items) = obj.get("allOf").and_then(Value::as_array) {
+        let builder = items
+            .iter()
+            .fold(AllOfBuilder::new().description(description), |b, item| {
+                b.item(convert(item, prefix))
+            });
+        return RefOr::T(Schema::AllOf(builder.build()));
+    }
+
+    match obj.get("type").and_then(Value::as_str) {
+        Some("object") => object(obj, description, prefix),
+        Some("array") => array(obj, description, prefix),
+        None if obj.contains_key("properties") => object(obj, description, prefix),
+        Some("string") => scalar(obj, description, SchemaType::Type(Type::String)),
+        Some("integer") => scalar(obj, description, SchemaType::Type(Type::Integer)),
+        Some("number") => scalar(obj, description, SchemaType::Type(Type::Number)),
+        Some("boolean") => scalar(obj, description, SchemaType::Type(Type::Boolean)),
+        _ => scalar(obj, description, SchemaType::AnyValue),
+    }
+}
+
+fn object(obj: &Map<String, Value>, description: Option<&str>, prefix: &str) -> RefOr<Schema> {
+    let mut b = ObjectBuilder::new()
+        .schema_type(SchemaType::Type(Type::Object))
+        .description(description);
+    if let Some(properties) = obj.get("properties").and_then(Value::as_object) {
+        for (name, property) in properties {
+            b = b.property(name, convert(property, prefix));
+        }
+    }
+    for required in obj
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+    {
+        b = b.required(required);
+    }
+    match obj.get("additionalProperties") {
+        Some(Value::Bool(allowed)) => {
+            b = b.additional_properties(Some(AdditionalProperties::<Schema>::FreeForm(*allowed)));
+        }
+        Some(schema @ Value::Object(_)) => {
+            b = b.additional_properties(Some(AdditionalProperties::RefOr(convert(schema, prefix))));
+        }
+        _ => {}
+    }
+    b = b.min_properties(count(obj, "minProperties"));
+    RefOr::T(Schema::Object(b.build()))
+}
+
+fn array(obj: &Map<String, Value>, description: Option<&str>, prefix: &str) -> RefOr<Schema> {
+    let mut b = ArrayBuilder::new().description(description);
+    if let Some(items) = obj.get("items") {
+        b = b.items(convert(items, prefix));
+    }
+    b = b
+        .min_items(count(obj, "minItems"))
+        .max_items(count(obj, "maxItems"))
+        .unique_items(obj.get("uniqueItems") == Some(&Value::Bool(true)));
+    RefOr::T(Schema::Array(b.build()))
+}
+
+fn scalar(
+    obj: &Map<String, Value>,
+    description: Option<&str>,
+    schema_type: SchemaType,
+) -> RefOr<Schema> {
+    let mut b = ObjectBuilder::new()
+        .schema_type(schema_type)
+        .description(description)
+        .format(
+            obj.get("format")
+                .and_then(Value::as_str)
+                .map(|f| SchemaFormat::Custom(f.to_string())),
+        )
+        .pattern(obj.get("pattern").and_then(Value::as_str))
+        .min_length(count(obj, "minLength"))
+        .max_length(count(obj, "maxLength"))
+        .minimum(number(obj, "minimum"))
+        .maximum(number(obj, "maximum"));
+    if let Some(values) = obj.get("enum").and_then(Value::as_array) {
+        b = b.enum_values(Some(values.iter().cloned()));
+    } else if let Some(value) = obj.get("const") {
+        b = b.enum_values(Some([value.clone()]));
+    }
+    RefOr::T(Schema::Object(b.build()))
+}
+
+fn count(obj: &Map<String, Value>, keyword: &str) -> Option<usize> {
+    obj.get(keyword)
+        .and_then(Value::as_u64)
+        .and_then(|n| usize::try_from(n).ok())
+}
+
+fn number(obj: &Map<String, Value>, keyword: &str) -> Option<utoipa::Number> {
+    let value = obj.get(keyword)?;
+    value
+        .as_u64()
+        .and_then(|n| usize::try_from(n).ok())
+        .map(utoipa::Number::UInt)
+        .or_else(|| {
+            value
+                .as_i64()
+                .and_then(|n| isize::try_from(n).ok())
+                .map(utoipa::Number::Int)
+        })
+        .or_else(|| value.as_f64().map(utoipa::Number::Float))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use utoipa::{PartialSchema, ToSchema};
+
+    fn every_ref(value: &Value, out: &mut Vec<String>) {
+        match value {
+            Value::Object(map) => {
+                if let Some(Value::String(r)) = map.get("$ref") {
+                    out.push(r.clone());
+                }
+                map.values().for_each(|v| every_ref(v, out));
+            }
+            Value::Array(items) => items.iter().for_each(|v| every_ref(v, out)),
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn components_are_named_for_their_specification() {
+        assert_eq!(
+            component_prefix("https://trusttasks.org/spec/vtc/join-requests/manifest/0.2#response"),
+            "VtcJoinRequestsManifestV0_2"
+        );
+        assert_eq!(
+            VetterList01Response::name(),
+            "VtcVettingVettersListV0_1Response"
+        );
+        assert_eq!(
+            VetterGrant01Payload::name(),
+            "VtcVettingVettersGrantV0_1Payload"
+        );
+        assert_eq!(
+            JoinManifest02VettingRequirements::name(),
+            "VtcJoinRequestsManifestV0_2VettingRequirements"
+        );
+    }
+
+    /// Every reference resolves to a component the type brings with it, so a
+    /// document built from these has no dangling `$ref` and no JSON Schema
+    /// `$defs` pointer OpenAPI cannot follow.
+    #[test]
+    fn every_reference_resolves_to_a_component_the_type_brings() {
+        fn check<T: ToSchema>() {
+            let mut components = vec![(T::name().into_owned(), <T as PartialSchema>::schema())];
+            T::schemas(&mut components);
+            let names: Vec<&str> = components.iter().map(|(n, _)| n.as_str()).collect();
+            let mut refs = Vec::new();
+            for (_, schema) in &components {
+                every_ref(&serde_json::to_value(schema).unwrap(), &mut refs);
+            }
+            assert!(components.len() > 1 || refs.is_empty());
+            for r in refs {
+                let name = r
+                    .strip_prefix("#/components/schemas/")
+                    .unwrap_or_else(|| panic!("{r} is not a component reference"));
+                assert!(names.contains(&name), "{r} dangles");
+            }
+        }
+        check::<VetterGrant01Payload>();
+        check::<VetterGrant01Response>();
+        check::<VetterList01Payload>();
+        check::<VetterList01Response>();
+        check::<VetterResend01Response>();
+        check::<VetterProfile01VettingMethod>();
+        check::<JoinManifest01Response>();
+        check::<JoinManifest02Response>();
+        check::<JoinManifest02VettingRequirements>();
+        check::<JoinManifest02CommunityBranding>();
+    }
+
+    #[test]
+    fn a_rendered_schema_keeps_the_specifications_bounds() {
+        let mut components = Vec::new();
+        VetterList01Response::schemas(&mut components);
+        let listed = components
+            .iter()
+            .find(|(n, _)| n == "VtcVettingVettersListV0_1ListedVetter")
+            .map(|(_, s)| serde_json::to_value(s).unwrap())
+            .expect("ListedVetter is a component");
+        assert_eq!(listed["additionalProperties"], false);
+        assert!(
+            listed["required"]
+                .as_array()
+                .unwrap()
+                .contains(&Value::from("vetterDid"))
+        );
+        assert_eq!(listed["properties"]["languages"]["maxItems"], 16);
+        assert_eq!(listed["properties"]["vetterDid"]["pattern"], "^did:");
+
+        let root = serde_json::to_value(VetterGrant01Payload::schema()).unwrap();
+        assert_eq!(root["properties"]["validitySeconds"]["minimum"], 86_400);
+        assert_eq!(root["required"], serde_json::json!(["memberDid"]));
+    }
+
+    #[test]
+    fn a_wrapper_is_invisible_on_the_wire() {
+        let json = serde_json::json!({ "memberDid": "did:key:zCarol" });
+        let wrapped: VetterGrant01Payload = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(wrapped.member_did.as_str(), "did:key:zCarol");
+        assert_eq!(serde_json::to_value(&wrapped).unwrap(), json);
+    }
+}

--- a/vta-sdk/src/protocols/join_requests.rs
+++ b/vta-sdk/src/protocols/join_requests.rs
@@ -106,126 +106,38 @@ pub struct JoinRequestSubmitBody {
 // Manifest — pre-submit discovery (join-requests/manifest/1.0)
 // ---------------------------------------------------------------------------
 
+/// The published `vtc/join-requests/manifest` types, generated from the
+/// specification: [`manifest::v0_1`] (criteria) and [`manifest::v0_2`]
+/// (criteria with their vetting requirements and `requirementsDigest`, and the
+/// community's branding). Their `Payload` and `Response` are the manifest's wire
+/// types; nothing in this crate restates them.
+///
+/// `manifest::v0_2::CommunityBranding` is also the body of the VTC's admin
+/// `GET`/`PUT /v1/community/branding`: what an admin stores is exactly what the
+/// manifest publishes.
+pub use trust_tasks_rs::specs::vtc::join_requests::manifest;
+
 /// Trust Task `type` for a join-request manifest request: discover the
 /// community's join evidence requirements. Public read; empty payload.
 pub const JOIN_REQUEST_MANIFEST_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/join-requests/manifest/0.1";
+    <manifest::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI;
 
 /// `#response` variant of [`JOIN_REQUEST_MANIFEST_TYPE`] — carries a
-/// [`JoinRequestManifestResponseBody`].
+/// [`manifest::v0_1::Response`].
 pub const JOIN_REQUEST_MANIFEST_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/join-requests/manifest/0.1#response";
+    <manifest::v0_1::Response as trust_tasks_rs::Payload>::TYPE_URI;
 
 /// Manifest 0.2: 0.1 plus an optional `vetting` requirements object and a
-/// `requirementsDigest` on each criterion. A community answers both versions;
-/// a 0.1 reader simply does not see the new members.
+/// `requirementsDigest` on each criterion, and the community's `branding`. A
+/// community answers both versions; a 0.1 reader simply does not see the new
+/// members.
 pub const JOIN_REQUEST_MANIFEST_0_2_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/join-requests/manifest/0.2";
+    <manifest::v0_2::Payload as trust_tasks_rs::Payload>::TYPE_URI;
 
-/// `#response` variant of [`JOIN_REQUEST_MANIFEST_0_2_TYPE`].
+/// `#response` variant of [`JOIN_REQUEST_MANIFEST_0_2_TYPE`] — carries a
+/// [`manifest::v0_2::Response`].
 pub const JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/join-requests/manifest/0.2#response";
-
-/// One community evidence requirement — a named DCQL Presentation
-/// Definition the applicant may present against.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct ManifestCriterion {
-    pub id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    pub presentation_definition: JsonValue,
-    /// Peer identity vetting this criterion requires (manifest 0.2). Absent on
-    /// a criterion that needs none.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<Object>))]
-    pub vetting: Option<super::vetting::VettingRequirements>,
-    /// `digestMultibase` over this criterion without this member (manifest
-    /// 0.2). An applicant records it when it starts gathering, so a change to
-    /// the requirements mid-application is detectable.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requirements_digest: Option<String>,
-}
-
-/// Manifest response: the community's join evidence requirements.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct JoinRequestManifestResponseBody {
-    pub community_did: String,
-    pub criteria: Vec<ManifestCriterion>,
-    /// How the community presents itself to an applicant's client (manifest
-    /// 0.2). Absent when the community has set none, and always absent from a
-    /// 0.1 answer.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub branding: Option<CommunityBranding>,
-}
-
-/// Longest branding `displayName`.
-pub const MAX_BRANDING_DISPLAY_NAME_CHARS: usize = 128;
-/// Longest branding `logoUrl`.
-pub const MAX_BRANDING_LOGO_URL_CHARS: usize = 2048;
-
-/// A community's presentation — `join-requests/manifest/0.2`'s `branding`, and
-/// the body of the VTC's `GET`/`PUT /v1/community/branding`. Every member is
-/// optional. Presentation only: a client never trusts a community because of
-/// how it is branded.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-pub struct CommunityBranding {
-    /// The name to show; 1–128 characters.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub display_name: Option<String>,
-    /// `#rrggbb`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub accent_color: Option<String>,
-    /// An `https` URL of at most 2048 characters.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub logo_url: Option<String>,
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<JsonValue>,
-}
-
-impl CommunityBranding {
-    /// Nothing set: a community with this branding publishes none.
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.display_name.is_none()
-            && self.accent_color.is_none()
-            && self.logo_url.is_none()
-            && self.ext.is_none()
-    }
-
-    /// Check the bounds and patterns.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`](super::vetting::ShapeError) for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), super::vetting::ShapeError> {
-        use super::vetting::{ShapeError, shape};
-        shape::optional_length(
-            "displayName",
-            self.display_name.as_deref(),
-            MAX_BRANDING_DISPLAY_NAME_CHARS,
-        )?;
-        if let Some(color) = &self.accent_color {
-            let b = color.as_bytes();
-            if b.len() != 7 || b[0] != b'#' || !b[1..].iter().all(u8::is_ascii_hexdigit) {
-                return Err(ShapeError::Field {
-                    field: "accentColor",
-                    rule: "must be #rrggbb",
-                });
-            }
-        }
-        match &self.logo_url {
-            Some(url) => shape::https_url("logoUrl", url, MAX_BRANDING_LOGO_URL_CHARS),
-            None => Ok(()),
-        }
-    }
-}
+    <manifest::v0_2::Response as trust_tasks_rs::Payload>::TYPE_URI;
 
 // ---------------------------------------------------------------------------
 // Status — applicant poll (join-requests/status/1.0)

--- a/vta-sdk/src/protocols/vetting.rs
+++ b/vta-sdk/src/protocols/vetting.rs
@@ -523,7 +523,6 @@ checked_by_schema!(
     vetters::grant::v0_1::Payload,
     vetters::grant::v0_1::Response,
     vetters::profile::v0_1::Response,
-    vetters::list::v0_1::Response,
     vetters::resend::v0_1::Payload,
     vetters::resend::v0_1::Response,
 );
@@ -559,8 +558,12 @@ impl CheckShape for vetters::profile::v0_1::Payload {
         against_own_schema(self)?;
         // `VetterEvent`: "`endDate` is on or after `startDate` and no more than
         // 31 days after it; JSON Schema cannot compare two members, so the
-        // community checks both".
+        // community checks both". Its `url` is a `format: uri` the validator
+        // does not assert.
         for event in &self.events {
+            if let Some(url) = &event.url {
+                shape::https_uri("events.url", url)?;
+            }
             let (start, end) = (event.start_date.0, event.end_date.0);
             if end < start {
                 return Err(ShapeError::Field {
@@ -596,12 +599,29 @@ impl CheckShape for vetters::list::v0_1::Payload {
     }
 }
 
+impl CheckShape for vetters::list::v0_1::Response {
+    /// The schema, and each listed event's `url` as an absolute https URI,
+    /// which the validator does not assert.
+    fn check_shape(&self) -> Result<(), ShapeError> {
+        against_own_schema(self)?;
+        for event in self.vetters.iter().flat_map(|vetter| &vetter.events) {
+            if let Some(url) = &event.url {
+                shape::https_uri("vetters.events.url", url)?;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl CheckShape for VettingRequirements {
     /// A community refuses to publish requirements that fail this, and a client
     /// treats a criterion that fails it as unsatisfiable rather than guess
     /// (`vtc/join-requests/manifest/0.2`, Conformance 3).
     fn check_shape(&self) -> Result<(), ShapeError> {
         against_own_definition::<manifest::Response>("VettingRequirements", self)?;
+        if let Some(url) = &self.governance_framework_url {
+            shape::https_uri("governanceFrameworkUrl", url)?;
+        }
         if self
             .min_by_method
             .keys()
@@ -617,8 +637,14 @@ impl CheckShape for VettingRequirements {
 }
 
 impl CheckShape for manifest::CommunityBranding {
+    /// The manifest's definition, and `logoUrl` as an absolute https URI, which
+    /// the validator does not assert. A client fetches the logo from it.
     fn check_shape(&self) -> Result<(), ShapeError> {
-        against_own_definition::<manifest::Response>("CommunityBranding", self)
+        against_own_definition::<manifest::Response>("CommunityBranding", self)?;
+        if let Some(url) = &self.logo_url {
+            shape::https_uri("logoUrl", url)?;
+        }
+        Ok(())
     }
 }
 
@@ -895,6 +921,46 @@ pub(crate) mod shape {
             .any(|(i, v)| values[..i].contains(v))
     }
 
+    /// Longest value a vetting schema gives `format: uri`.
+    const MAX_URI_CHARS: usize = 2048;
+
+    /// A member the vetting schemas give `format: uri`, `pattern: ^https://`
+    /// and `maxLength: 2048` — an event's `url`, branding's `logoUrl`, the
+    /// requirements' `governanceFrameworkUrl` — is an absolute https URI
+    /// (RFC 3986) with a host. The schema validator treats `format` as an
+    /// annotation and does not assert it, and the pattern alone lets
+    /// `https://a b` through, so the URI rule is checked here.
+    pub(crate) fn https_uri(field: &'static str, value: &str) -> Result<(), ShapeError> {
+        let fail = |rule: &'static str| -> Result<(), ShapeError> {
+            Err(ShapeError::Field { field, rule })
+        };
+        if value.chars().any(|c| c.is_whitespace() || c.is_control()) {
+            return fail("must not contain whitespace or control characters");
+        }
+        if value.chars().count() > MAX_URI_CHARS {
+            return fail("must be at most 2048 characters");
+        }
+        let Some(rest) = value.strip_prefix("https://") else {
+            return fail("must be an absolute https URI");
+        };
+        let uri_character =
+            |b: u8| b.is_ascii_alphanumeric() || b"-._~:/?#[]@!$&'()*+,;=%".contains(&b);
+        let escapes_are_well_formed = value.bytes().enumerate().all(|(i, b)| {
+            b != b'%'
+                || value
+                    .as_bytes()
+                    .get(i + 1..i + 3)
+                    .is_some_and(|hex| hex.iter().all(u8::is_ascii_hexdigit))
+        });
+        let has_authority = !rest.is_empty() && !rest.starts_with(['/', '?', '#']);
+        let parses = url::Url::parse(value)
+            .is_ok_and(|u| u.scheme() == "https" && u.host_str().is_some_and(|h| !h.is_empty()));
+        if value.bytes().all(uri_character) && escapes_are_well_formed && has_authority && parses {
+            return Ok(());
+        }
+        fail("must be an absolute https URI")
+    }
+
     /// Portraits are not carried (D17).
     pub(crate) fn no_portrait<'a>(
         field: &'static str,
@@ -1025,6 +1091,12 @@ mod tests {
         assert!(broken(&|p| p["events"][0]["name"] = json!("x".repeat(201))));
         assert!(broken(
             &|p| p["events"][0]["url"] = json!("http://events.example.org")
+        ));
+        assert!(broken(
+            &|p| p["events"][0]["url"] = json!("https://events.example.org/kernel meetup")
+        ));
+        assert!(broken(
+            &|p| p["events"][0]["url"] = json!("https://events.example.org/\u{7}")
         ));
         assert!(broken(&|p| p["events"][0]["endDate"] = json!("2026-10-04")));
         assert!(broken(&|p| p["events"][0]["endDate"] = json!("2026-11-06")));
@@ -1278,6 +1350,14 @@ mod tests {
             with("governanceFrameworkUrl", json!("http://gov.example")),
             "governance text is served over https"
         );
+        assert!(with(
+            "governanceFrameworkUrl",
+            json!("https://gov.example/frame work")
+        ));
+        assert!(with(
+            "governanceFrameworkUrl",
+            json!("https://gov.example/\u{1b}")
+        ));
         assert!(
             with("decisionSla", json!(format!("PT{}S", "1".repeat(30)))),
             "durations are at most 32 characters"
@@ -1460,11 +1540,85 @@ mod tests {
             json!({ "accentColor": "red" }),
             json!({ "accentColor": "#12345g" }),
             json!({ "logoUrl": "http://kernel.example.org/logo.svg" }),
+            json!({ "logoUrl": "https://kernel.example.org/my logo.svg" }),
+            json!({ "logoUrl": "https://kernel.example.org/logo\u{0}.svg" }),
             json!({ "displayName": "x".repeat(129) }),
             json!({ "displayName": "" }),
             json!({ "tagline": "x" }),
         ] {
             assert!(read_branding(&bad).is_err(), "{bad}");
+        }
+        // A branding built in code, as the community stores it, is held to the
+        // same rule.
+        let spaced: manifest::CommunityBranding =
+            serde_json::from_value(json!({ "logoUrl": "https://kernel.example.org/my logo.svg" }))
+                .unwrap();
+        assert!(spaced.check_shape().is_err());
+    }
+
+    #[test]
+    fn a_format_uri_member_is_an_absolute_https_uri() {
+        // The schema validator does not assert `format: uri`, and the
+        // `^https://` pattern alone admits every one of these refusals.
+        for good in [
+            "https://events.example.org",
+            "https://events.example.org/kms?day=1#hall-b",
+            "https://example.org/caf%C3%A9",
+            "https://[2001:db8::1]:8443/logo.svg",
+        ] {
+            assert_eq!(shape::https_uri("url", good), Ok(()), "{good}");
+        }
+        let whitespace = "must not contain whitespace or control characters";
+        let not_a_uri = "must be an absolute https URI";
+        let too_long = format!("https://example.org/{}", "a".repeat(2048));
+        for (bad, rule) in [
+            ("https://events.example.org/kernel meetup", whitespace),
+            ("https://events.example.org/\u{7}", whitespace),
+            ("https://events.example.org/\tx", whitespace),
+            ("https://events.example.org/\u{85}", whitespace),
+            ("http://events.example.org", not_a_uri),
+            ("events.example.org", not_a_uri),
+            ("https://", not_a_uri),
+            ("https:///path", not_a_uri),
+            ("https://?q=1", not_a_uri),
+            ("https://example.org/%zz", not_a_uri),
+            ("https://example.org/%4", not_a_uri),
+            ("https://example.org/café", not_a_uri),
+            ("https://example.org/<logo>", not_a_uri),
+            (too_long.as_str(), "must be at most 2048 characters"),
+        ] {
+            assert_eq!(
+                shape::https_uri("url", bad),
+                Err(ShapeError::Field { field: "url", rule }),
+                "{bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_listed_event_url_is_an_absolute_https_uri() {
+        // A listing is the stored profiles as the community lists them: without
+        // `listed`, with the vetter's DID and the grant and update times.
+        let listing = |url: &str| {
+            let mut vetter = profile_json();
+            vetter["events"][0]["url"] = json!(url);
+            let members = vetter.as_object_mut().unwrap();
+            members.remove("listed");
+            members.insert("vetterDid".into(), json!("did:key:zVetter"));
+            members.insert("grantValidUntil".into(), json!("2027-01-01T00:00:00Z"));
+            members.insert("updatedAt".into(), json!("2026-09-01T00:00:00Z"));
+            json!({ "vetters": [vetter] })
+        };
+        type Listing = vetters::list::v0_1::Response;
+        assert!(!refused::<Listing>(listing(
+            "https://events.example.org/kms"
+        )));
+        for bad in [
+            "https://events.example.org/kernel meetup",
+            "https://events.example.org/\u{7}",
+            "http://events.example.org",
+        ] {
+            assert!(refused::<Listing>(listing(bad)), "{bad:?}");
         }
     }
 

--- a/vta-sdk/src/protocols/vetting.rs
+++ b/vta-sdk/src/protocols/vetting.rs
@@ -1,115 +1,201 @@
-//! Wire types for peer identity vetting — how an applicant is vetted by
-//! existing members before joining a Verifiable Trust Community.
+//! Peer identity vetting — how an applicant is vetted by existing members before
+//! joining a Verifiable Trust Community.
 //!
-//! Design: OpenVTC `docs/design/vetting-process.md`. Four Trust Tasks carry
-//! the exchange:
+//! Design: OpenVTC `docs/design/vetting-process.md`.
 //!
-//! | Type URI | From → to | Payload |
+//! ## The wire types are the published specifications'
+//!
+//! Every Trust Task payload and response in this family is the type
+//! `trust-tasks-codegen` generates from its specification, re-exported here from
+//! `trust_tasks_rs::specs`. This crate does not restate any of them: a change to
+//! a vetting wire shape lands in dtgwg-trust-tasks-tf and arrives here with a
+//! `trust-tasks-rs` release.
+//!
+//! | Type URI | From → to | Generated module |
 //! |---|---|---|
-//! | `spec/vetting/request/0.1` | applicant → vetter | [`VettingRequestBody`] → [`VettingRequestAcceptedBody`] |
-//! | `spec/vetting/session/0.1` | vetter → applicant | [`VettingSessionBody`] → [`VettingSessionResponseBody`] |
-//! | `spec/vetting/decline/0.1` | vetter → applicant | [`VettingDeclineBody`] |
-//! | `spec/vtc/vetting/revoke-statement/0.1` | vetter → community | [`RevokeStatementBody`] → [`RevokeStatementResponseBody`] |
-//! | `spec/vtc/vetting/vetters/grant/0.1` | community admin → community | [`VetterGrantBody`] → [`VetterGrantResponseBody`] |
-//! | `spec/vtc/vetting/vetters/profile/0.1` | vetter → community | [`VetterProfileBody`] → [`VetterProfileResponseBody`] |
-//! | `spec/vtc/vetting/vetters/list/0.1` | member or applicant → community | [`VetterListBody`] → [`VetterListResponseBody`] |
-//! | `spec/vtc/vetting/vetters/resend/0.1` | vetter → community | [`VetterResendBody`] → [`VetterResendResponseBody`] |
+//! | `spec/vetting/request/0.1` | applicant → vetter | [`request::v0_1`] |
+//! | `spec/vetting/session/0.1` | vetter → applicant | [`session::v0_1`] — its `Response` carries the signed [`session::v0_1::VettingCard`] |
+//! | `spec/vetting/decline/0.1` | vetter → applicant | [`decline::v0_1`] |
+//! | `spec/vtc/vetting/revoke-statement/0.1` | vetter → community | [`revoke_statement::v0_1`] |
+//! | `spec/vtc/vetting/vetters/grant/0.1` | community admin → community | [`vetters::grant::v0_1`] |
+//! | `spec/vtc/vetting/vetters/profile/0.1` | vetter → community | [`vetters::profile::v0_1`] |
+//! | `spec/vtc/vetting/vetters/list/0.1` | member or applicant → community | [`vetters::list::v0_1`] |
+//! | `spec/vtc/vetting/vetters/resend/0.1` | vetter → community | [`vetters::resend::v0_1`] |
 //!
-//! The community's admin REST surface for vetters shares the module:
-//! [`VetterGrantListResponse`] (`GET /v1/vetting/vetters`) and
-//! [`AutoGrantConfig`] / [`AutoGrantStatus`] (`GET`/`PUT /v1/vetting/auto-grant`).
+//! Each module holds the task's `Payload` and, where it has one, its `Response`.
+//! The modules are versioned: a new specification version arrives beside the old
+//! one instead of changing what an existing path means.
+//!
+//! What a community requires rides its join manifest
+//! (`vtc/join-requests/manifest/0.2`) as a [`VettingRequirements`] on each
+//! criterion. Its vocabulary — [`VettingMethod`], [`VettingRelationship`],
+//! [`VettingDocumentation`], [`ClaimType`] — is the one statements are counted
+//! in, so it is re-exported here from that specification's module. **Every number
+//! in the requirements is the community's policy**: this crate supplies no
+//! default statement count, method floor or age limit, and nothing here should
+//! grow one.
+//!
+//! ## Working with generated types
+//!
+//! Generated structs are `#[non_exhaustive]`: build one with its `builder()` (or
+//! by deserializing), then read or set its public fields. A constrained string
+//! is a newtype that checks the schema's `pattern` and length when it is made
+//! (`TryFrom<&str>`, `FromStr`) and dereferences to `String`. Unset optional
+//! members are omitted rather than sent as `null`, and unknown members are
+//! refused.
+//!
+//! What a constructor cannot check — array bounds and uniqueness, `oneOf`,
+//! dependent members — the embedded schema does. [`CheckShape`] validates a value
+//! against it and adds the few rules no JSON Schema can state, such as an event's
+//! `endDate` against its `startDate`.
+//!
+//! **A receiver reads with [`read_checked`]**, not with `serde_json` and
+//! [`CheckShape`]: some constructors normalise what they parse (a date written
+//! `2026-1-05` parses and re-serialises as `2026-01-05`), so only the JSON as
+//! received shows whether it met the schema. [`read_checked`] validates that JSON
+//! first, then parses it, then applies the rules above.
+//!
+//! **Signatures and digests cover the JSON as received.** A generated type keeps
+//! only the members its schema names, so re-serialising a parsed card, proof or
+//! presentation can drop members the signer covered. Verify and digest the JSON
+//! you received, as `crate::vetting` does.
+//!
+//! ## What is written by hand
+//!
+//! Only what no generated module carries:
+//!
+//! - [`IdentityVettingEndorsement`], the `endorsement` body of a Vetting
+//!   Statement. It is a credential body (`vetting/_shared/0.1/identity-vetting`),
+//!   not a Trust Task, and the codegen generates no type for shared definitions;
+//!   its members use the generated vocabulary;
+//! - the rules [`CheckShape`] and [`check_request`] add beyond the schemas;
+//! - the extended error codes the specifications declare in their front matter;
+//! - the community admin REST bodies that are not Trust Tasks: the grant listing
+//!   ([`VetterGrantListResponse`]) and the automatic-grant configuration
+//!   ([`AutoGrantConfig`], [`AutoGrantStatus`]).
 //!
 //! A vetter is named by a **vetter role credential**: a DTG
 //! `EndorsementCredential` the community issues to the member, with endorsement
 //! `{ type: "CommunityRole", role: "vetter", communityDid }` and a
-//! `credentialStatus` so it can be revoked. The community counts a statement
-//! only from a vetter whose grant it recorded; the vetter presents the same
-//! credential to an applicant (`crate::vetting::eligibility`).
+//! `credentialStatus` so it can be revoked. The community counts a statement only
+//! from a vetter whose grant it recorded; the vetter presents the same credential
+//! to an applicant (`crate::vetting::eligibility`). The Vetting Statement itself
+//! travels over `credential-exchange/issue/0.1`.
 //!
-//! The Vetting Statement itself travels over the existing
-//! `credential-exchange/issue/0.1`. It is a DTG `EndorsementCredential` whose
-//! `endorsement` is an [`IdentityVettingEndorsement`] — no new credential type.
-//!
-//! What a community requires rides its join manifest as a
-//! [`VettingRequirements`] on each criterion. **Every number in it is the
-//! community's policy**: this crate supplies no default statement count,
-//! method floor or age limit, and nothing here should grow one.
-//!
-//! This module is serde only, so any consumer can read the shapes. Building,
-//! signing and verifying the card and the statement live in
-//! `crate::vetting` (feature `vetting`).
+//! Building, signing and verifying the card and the statement, and counting
+//! statements against requirements, live in `crate::vetting` (feature
+//! `vetting`).
 //!
 //! ## Refusals are errors, not responses
 //!
 //! A vetter that will not take a request answers with a framework
-//! `trust-task-error` carrying one of the `VETTING_REQUEST_ERR_*` codes, never
-//! a `#response` with an "outcome" field. One exception is deliberate: a request
+//! `trust-task-error` carrying one of the `VETTING_REQUEST_ERR_*` codes, never a
+//! `#response` with an "outcome" field. One exception is deliberate: a request
 //! whose **short ticket code** is wrong gets no answer at all, so a guesser
 //! learns nothing from the reply (design §8.3).
 
-use std::collections::BTreeMap;
-
-use chrono::{DateTime, Duration, NaiveDate, Utc};
+use chrono::{DateTime, Duration, Utc};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+pub use trust_tasks_rs::specs::vetting::{decline, request, session};
+pub use trust_tasks_rs::specs::vtc::join_requests::manifest::v0_2::{
+    ClaimType, VettingDocumentation, VettingMethod, VettingRelationship, VettingRequirements,
+    VettingRequirementsEligibleVetters, VettingRequirementsIndependence,
+    VettingRequirementsInvitation,
+};
+pub use trust_tasks_rs::specs::vtc::vetting::{revoke_statement, vetters};
+
+use trust_tasks_rs::specs::vtc::join_requests::manifest::v0_2 as manifest;
+
 // ---------------------------------------------------------------------------
-// Type URIs
+// Type URIs — the generated types' own, so the URI a handler answers on is the
+// one the specification publishes.
 // ---------------------------------------------------------------------------
 
 /// Applicant → vetter: ask to be vetted for one community.
-pub const VETTING_REQUEST_TYPE: &str = "https://trusttasks.org/spec/vetting/request/0.1";
+pub const VETTING_REQUEST_TYPE: &str =
+    <request::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI;
 /// `#response` variant of [`VETTING_REQUEST_TYPE`] — the vetter accepted.
 pub const VETTING_REQUEST_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/spec/vetting/request/0.1#response";
+    <request::v0_1::Response as trust_tasks_rs::Payload>::TYPE_URI;
 
 /// Vetter → applicant: open the session. The response carries the signed card.
-pub const VETTING_SESSION_TYPE: &str = "https://trusttasks.org/spec/vetting/session/0.1";
+pub const VETTING_SESSION_TYPE: &str =
+    <session::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI;
 /// `#response` variant of [`VETTING_SESSION_TYPE`].
 pub const VETTING_SESSION_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/spec/vetting/session/0.1#response";
+    <session::v0_1::Response as trust_tasks_rs::Payload>::TYPE_URI;
 
 /// Vetter → applicant: the vetter will not issue a statement.
-pub const VETTING_DECLINE_TYPE: &str = "https://trusttasks.org/spec/vetting/decline/0.1";
+pub const VETTING_DECLINE_TYPE: &str =
+    <decline::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI;
 
 /// Vetter → community: withdraw a statement the vetter issued.
 pub const VETTING_REVOKE_STATEMENT_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/vetting/revoke-statement/0.1";
+    <revoke_statement::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI;
 /// `#response` variant of [`VETTING_REVOKE_STATEMENT_TYPE`].
 pub const VETTING_REVOKE_STATEMENT_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/vetting/revoke-statement/0.1#response";
+    <revoke_statement::v0_1::Response as trust_tasks_rs::Payload>::TYPE_URI;
+
 /// Community admin → community: name a member as a vetter by issuing them a
 /// revocable vetter role credential.
 pub const VETTING_VETTER_GRANT_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/vetting/vetters/grant/0.1";
+    <vetters::grant::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI;
 /// `#response` variant of [`VETTING_VETTER_GRANT_TYPE`].
 pub const VETTING_VETTER_GRANT_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/vetting/vetters/grant/0.1#response";
+    <vetters::grant::v0_1::Response as trust_tasks_rs::Payload>::TYPE_URI;
+
 /// Vetter → community: publish (or replace) the sender's vetter profile.
 pub const VETTING_VETTER_PROFILE_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/vetting/vetters/profile/0.1";
+    <vetters::profile::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI;
 /// `#response` variant of [`VETTING_VETTER_PROFILE_TYPE`].
 pub const VETTING_VETTER_PROFILE_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/vetting/vetters/profile/0.1#response";
-/// Member or applicant → community: find vetters by language, place, method
-/// or event.
+    <vetters::profile::v0_1::Response as trust_tasks_rs::Payload>::TYPE_URI;
+
+/// Member or applicant → community: find vetters by language, place, method or
+/// event.
 pub const VETTING_VETTER_LIST_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/vetting/vetters/list/0.1";
+    <vetters::list::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI;
 /// `#response` variant of [`VETTING_VETTER_LIST_TYPE`].
 pub const VETTING_VETTER_LIST_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/vetting/vetters/list/0.1#response";
+    <vetters::list::v0_1::Response as trust_tasks_rs::Payload>::TYPE_URI;
+
 /// Vetter → community: deliver the sender's live vetter grant credential again.
 pub const VETTING_VETTER_RESEND_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/vetting/vetters/resend/0.1";
+    <vetters::resend::v0_1::Payload as trust_tasks_rs::Payload>::TYPE_URI;
 /// `#response` variant of [`VETTING_VETTER_RESEND_TYPE`].
 pub const VETTING_VETTER_RESEND_RESPONSE_TYPE: &str =
-    "https://trusttasks.org/spec/vtc/vetting/vetters/resend/0.1#response";
+    <vetters::resend::v0_1::Response as trust_tasks_rs::Payload>::TYPE_URI;
 
+// ---------------------------------------------------------------------------
+// Extended error codes, as each specification's front matter declares them.
+// The codegen carries no error codes, so these are the one place they are
+// spelled.
+// ---------------------------------------------------------------------------
+
+/// `vetting/request` refusal: a scanned ticket's secret did not match. Never
+/// sent for a short code — see the module docs.
+pub const VETTING_REQUEST_ERR_INVALID_TICKET: &str = "vetting/request:invalidTicket";
+/// `vetting/request` refusal: the vetter has no capacity.
+pub const VETTING_REQUEST_ERR_CAPACITY: &str = "vetting/request:capacity";
+/// `vetting/request` refusal: the addressee is not currently a vetter for the
+/// named community.
+pub const VETTING_REQUEST_ERR_NOT_ELIGIBLE: &str = "vetting/request:notEligible";
+/// `vetting/request` refusal: the vetter declines, without a reason.
+pub const VETTING_REQUEST_ERR_DECLINED: &str = "vetting/request:declined";
+/// `vetting/request` refusal: the vetter does not offer the requested method.
+pub const VETTING_REQUEST_ERR_METHOD_UNAVAILABLE: &str = "vetting/request:methodUnavailable";
 /// `vtc/vetting/vetters/profile` refusal: the sender is not an active member
 /// holding a live vetter grant.
 pub const VETTING_VETTER_PROFILE_ERR_NOT_ELIGIBLE: &str = "vtc/vetting/vetters/profile:notEligible";
 /// `vtc/vetting/vetters/resend` refusal: the sender holds no live vetter grant.
 pub const VETTING_VETTER_RESEND_ERR_NOT_GRANTED: &str = "vtc/vetting/vetters/resend:notGranted";
+
+// ---------------------------------------------------------------------------
+// Shared vocabulary that no schema carries
+// ---------------------------------------------------------------------------
 
 /// `credentialSubject.endorsement.type` of a community role credential — the
 /// role VEC a community issues to a member.
@@ -135,90 +221,24 @@ pub fn role_matches(held: &str, required: &str) -> bool {
 pub const IDENTITY_VETTING_ENDORSEMENT_TYPE: &str =
     "https://firstperson.network/endorsements/identity-vetting/0.1";
 
-/// The `type` members a Vetting Card carries, in order. It is a profile of the
-/// r-card, which is itself a Verifiable Data Structure.
-pub const VETTING_CARD_TYPES: [&str; 3] =
-    ["VerifiableDataStructure", "RelationshipCard", "VettingCard"];
+/// The `type` members a Vetting Card carries. It is a profile of the r-card,
+/// which is itself a Verifiable Data Structure.
+pub const VETTING_CARD_TYPES: [session::v0_1::VettingCardTypeItem; 3] = [
+    session::v0_1::VettingCardTypeItem::VerifiableDataStructure,
+    session::v0_1::VettingCardTypeItem::RelationshipCard,
+    session::v0_1::VettingCardTypeItem::VettingCard,
+];
 
 /// Vault `purpose` a holder files received statements under.
 pub const VETTING_VAULT_PURPOSE: &str = "vetting";
 
-/// `vetting/request` refusal: a scanned ticket's secret did not match. Never
-/// sent for a short code — see the module docs.
-pub const VETTING_REQUEST_ERR_INVALID_TICKET: &str = "vetting/request:invalidTicket";
-/// `vetting/request` refusal: the vetter has no capacity.
-pub const VETTING_REQUEST_ERR_CAPACITY: &str = "vetting/request:capacity";
-/// `vetting/request` refusal: the addressee is not currently a vetter for the
-/// named community.
-pub const VETTING_REQUEST_ERR_NOT_ELIGIBLE: &str = "vetting/request:notEligible";
-/// `vetting/request` refusal: the vetter declines, without a reason.
-pub const VETTING_REQUEST_ERR_DECLINED: &str = "vetting/request:declined";
-/// `vetting/request` refusal: the vetter does not offer the requested method.
-pub const VETTING_REQUEST_ERR_METHOD_UNAVAILABLE: &str = "vetting/request:methodUnavailable";
-
-// ---------------------------------------------------------------------------
-// Shared vocabulary
-// ---------------------------------------------------------------------------
-
-/// How a vetter established who the applicant is.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub enum VettingMethod {
-    /// Both people in the same place.
-    InPerson,
-    /// A live video call.
-    Video,
-    /// The vetter already knows the applicant — the Linux kernel's own written
-    /// standard ("worked with you for some period of time").
-    PriorAcquaintance,
-}
-
-impl VettingMethod {
-    /// The wire form, as used in `needs` strings.
-    #[must_use]
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::InPerson => "inPerson",
-            Self::Video => "video",
-            Self::PriorAcquaintance => "priorAcquaintance",
-        }
-    }
-
-    /// Inverse of [`Self::as_str`].
-    #[must_use]
-    pub fn parse(s: &str) -> Option<Self> {
-        match s {
-            "inPerson" => Some(Self::InPerson),
-            "video" => Some(Self::Video),
-            "priorAcquaintance" => Some(Self::PriorAcquaintance),
-            _ => None,
-        }
-    }
-}
-
-/// The vetter's declared relationship to the applicant. Independence rules in
-/// [`Independence`] cap how many counted statements may carry each value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub enum DeclaredRelationship {
-    /// No prior relationship.
-    None,
-    /// Worked together in the community.
-    CommunityColleague,
-    /// Same employer.
-    SameEmployer,
-    /// Family.
-    Family,
-    /// Some other personal relationship.
-    OtherPersonal,
-}
+/// The claim type a card, session or statement never names: portraits are not
+/// carried (design D17).
+pub const PORTRAIT_CLAIM_TYPE: &str = "person.portrait";
 
 /// Well-known documentation values. Documentation is **each vetter's choice**
-/// (design D16), so the wire type is an open string; these are the names
-/// clients should use for the common cases.
+/// (design D16), so the wire type ([`VettingDocumentation`]) is an open token;
+/// these are the names clients should use for the common cases.
 pub mod documentation {
     /// A passport.
     pub const PASSPORT: &str = "passport";
@@ -226,197 +246,43 @@ pub mod documentation {
     pub const NATIONAL_ID: &str = "nationalId";
     /// A driver licence.
     pub const DRIVER_LICENCE: &str = "driverLicence";
-    /// No document: the vetter knows the person (`priorAcquaintance`).
+    /// No document: the vetter knows the person (`priorAcquaintance`). A policy
+    /// value only — a statement records "no document" as an empty list.
     pub const NONE: &str = "none";
 }
 
+/// Shortest vetter grant a community may issue: one day. The `minimum`
+/// `vtc/vetting/vetters/grant/0.1` sets on `validitySeconds`; a test pins the
+/// two together.
+pub const MIN_VETTER_GRANT_VALIDITY_SECONDS: u64 = 86_400;
+/// Longest vetter grant a community may issue: two years. The schema's
+/// `maximum` on `validitySeconds`.
+pub const MAX_VETTER_GRANT_VALIDITY_SECONDS: u64 = 2 * 365 * 86_400;
+/// A grant's validity when the request names none: one year
+/// (`vtc/vetting/vetters/grant/0.1`).
+pub const DEFAULT_VETTER_GRANT_VALIDITY_SECONDS: u64 = 365 * 86_400;
+
+/// A listing page when the request names no `limit`
+/// (`vtc/vetting/vetters/list/0.1`).
+pub const DEFAULT_VETTER_LIST_LIMIT: u64 = 50;
+
+/// Longest span of one vetter event, `endDate − startDate`, in days. The
+/// profile schema states this in prose, because JSON Schema cannot compare two
+/// members.
+pub const MAX_VETTER_EVENT_SPAN_DAYS: i64 = 31;
+
 // ---------------------------------------------------------------------------
-// Requirements (manifest 0.2)
+// Durations
 // ---------------------------------------------------------------------------
 
-/// What a criterion in a community's join manifest requires of vetting.
+/// Parse the subset of ISO 8601 durations the requirements use: `P[n]W`,
+/// `P[n]D` and a `T` part with `H`, `M`, `S`, in any combination (`P1DT12H`).
+/// Years and months are refused — their length depends on the calendar, and an
+/// age limit that means different things on different days is not a limit.
 ///
-/// Deliberately **not** `deny_unknown_fields`: this is a shape a client reads
-/// from a community, and a newer community adding a member must not make an
-/// older client unable to read the rest.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct VettingRequirements {
-    /// Version of this requirements object's shape (`"0.1"`).
-    pub version: String,
-    /// The endorsement `type` a counted statement carries — normally
-    /// [`IDENTITY_VETTING_ENDORSEMENT_TYPE`].
-    pub statement_type: String,
-    /// Distinct eligible vetters required, counted by member, not by DID.
-    pub min_statements: u32,
-    /// Per-method floors, e.g. at least one `inPerson`.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub min_by_method: BTreeMap<VettingMethod, u32>,
-    /// Methods that count at all.
-    pub accepted_methods: Vec<VettingMethod>,
-    /// Optional documentation floor. **Absent by default**: each vetter decides
-    /// what documentation they accept (D16).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub accepted_document_classes: Option<Vec<String>>,
-    /// Claim types a counted statement must mark verified, and which the
-    /// identity commitment is computed over.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub required_claims: Vec<String>,
-    /// Claim types an applicant may add to the card.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub optional_claims: Vec<String>,
-    /// ISO 8601 duration; a statement older than this at decision time does
-    /// not count. Absent: no age limit beyond the statement's own `validUntil`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_statement_age: Option<String>,
-    /// How a vetter's eligibility is proven.
-    pub eligible_vetters: EligibleVetters,
-    /// Independence caps.
-    #[serde(default)]
-    pub independence: Independence,
-    /// Whether an invitation credential must accompany the statements. Absent:
-    /// the criterion's `presentationDefinition` alone decides.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub invitation: Option<InvitationRequirement>,
-    /// ISO 8601 duration the community commits to deciding a referred
-    /// application within. Clients use it in place of a fixed pending expiry.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub decision_sla: Option<String>,
-    /// ISO 8601 duration an application started under an older
-    /// `requirementsDigest` is still evaluated under that version.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requirements_grace: Option<String>,
-    /// Where the governance framework (and the vetter attestation text) lives.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub governance_framework_url: Option<String>,
-}
-
-/// How vetter eligibility is proven.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct EligibleVetters {
-    /// The community role a vetter must hold (normally `"vetter"`), evidenced
-    /// by the community-issued role VEC.
-    pub role: String,
-}
-
-/// Independence rules over the counted statements.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Independence {
-    /// At most this many counted statements may declare each relationship.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub max_by_declared_relationship: BTreeMap<DeclaredRelationship, u32>,
-    /// Every statement must carry the same identity commitment.
-    #[serde(default)]
-    pub require_consistent_identity_commitment: bool,
-}
-
-/// Whether a VIC must accompany the vetting statements.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub enum InvitationRequirement {
-    /// A VIC is required.
-    Required,
-    /// A VIC may be presented.
-    Optional,
-    /// No VIC is expected.
-    None,
-}
-
-/// A [`VettingRequirements`] that cannot be evaluated.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[error("invalid vetting requirements: {0}")]
-pub struct InvalidRequirements(pub String);
-
-impl VettingRequirements {
-    /// Check the requirements can be evaluated as written. A community should
-    /// refuse to publish requirements that fail this, and a client should treat
-    /// a criterion that fails it as unsatisfiable rather than guess.
-    ///
-    /// # Errors
-    ///
-    /// [`InvalidRequirements`] naming the first problem found.
-    pub fn validate(&self) -> Result<(), InvalidRequirements> {
-        let (major, minor) = self.version.split_once('.').unwrap_or_default();
-        if major.is_empty()
-            || minor.is_empty()
-            || !major
-                .bytes()
-                .chain(minor.bytes())
-                .all(|b| b.is_ascii_digit())
-        {
-            return Err(InvalidRequirements(format!(
-                "version `{}` is not MAJOR.MINOR",
-                self.version
-            )));
-        }
-        if self.statement_type.is_empty() || self.statement_type.chars().count() > 512 {
-            return Err(InvalidRequirements(
-                "statementType is empty or longer than 512 characters".into(),
-            ));
-        }
-        if self.min_statements == 0 {
-            return Err(InvalidRequirements(
-                "minStatements must be at least 1 — a criterion that needs no statements has no vetting object".into(),
-            ));
-        }
-        if self.accepted_methods.is_empty() {
-            return Err(InvalidRequirements("acceptedMethods is empty".into()));
-        }
-        for method in self.min_by_method.keys() {
-            if !self.accepted_methods.contains(method) {
-                return Err(InvalidRequirements(format!(
-                    "minByMethod names `{}`, which acceptedMethods does not accept",
-                    method.as_str()
-                )));
-            }
-        }
-        shape::role("eligibleVetters.role", &self.eligible_vetters.role)
-            .map_err(|e| InvalidRequirements(e.to_string()))?;
-        if let Some(classes) = &self.accepted_document_classes {
-            shape::tokens("acceptedDocumentClasses", classes)
-                .map_err(|e| InvalidRequirements(e.to_string()))?;
-        }
-        if let Some(url) = &self.governance_framework_url
-            && (!url.starts_with("https://") || url.chars().count() > 2048)
-        {
-            return Err(InvalidRequirements(
-                "governanceFrameworkUrl must be an https URL of at most 2048 characters".into(),
-            ));
-        }
-        for (name, value) in [
-            ("maxStatementAge", &self.max_statement_age),
-            ("decisionSla", &self.decision_sla),
-            ("requirementsGrace", &self.requirements_grace),
-        ] {
-            if let Some(v) = value
-                && (v.len() > 32 || parse_iso8601_duration(v).is_none())
-            {
-                return Err(InvalidRequirements(format!(
-                    "{name} `{v}` is not a supported ISO 8601 duration (weeks, days, hours, minutes, seconds)"
-                )));
-            }
-        }
-        Ok(())
-    }
-
-    /// [`Self::max_statement_age`] as a duration. `None` when absent **or
-    /// unparseable** — call [`Self::validate`] first to tell the two apart.
-    #[must_use]
-    pub fn max_statement_age(&self) -> Option<Duration> {
-        self.max_statement_age
-            .as_deref()
-            .and_then(parse_iso8601_duration)
-    }
-}
-
-/// Parse the subset of ISO 8601 durations these requirements use: `P[n]W`,
-/// `P[n]D` and a `T` part with `H`, `M`, `S`, in any combination
-/// (`P1DT12H`). Years and months are refused — their length depends on the
-/// calendar, and an age limit that means different things on different days is
-/// not a limit.
+/// The manifest schema's `Duration` pattern admits exactly this subset, so a
+/// duration read from [`VettingRequirements`] fails here only when its number
+/// does not fit.
 #[must_use]
 pub fn parse_iso8601_duration(s: &str) -> Option<Duration> {
     /// Units in the order ISO 8601 writes them. Each may appear at most once,
@@ -468,80 +334,37 @@ pub fn parse_iso8601_duration(s: &str) -> Option<Duration> {
     Duration::try_seconds(date_seconds.checked_add(time_seconds)?)
 }
 
-// ---------------------------------------------------------------------------
-// vetting/request/0.1
-// ---------------------------------------------------------------------------
-
-/// A Vetting Ticket as presented by the applicant: either the short code the
-/// vetter read out, or the full ticket scanned from their QR.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum TicketPresentation {
-    /// The QR form: full-entropy secret, not subject to guess limits.
-    Scanned {
-        #[serde(rename = "ticketId")]
-        ticket_id: String,
-        /// base64url, 32 bytes.
-        secret: String,
-    },
-    /// The spoken form: `XXXX-XXXX`, 40 bits.
-    Code {
-        /// Crockford base32, `XXXX-XXXX`.
-        code: String,
-    },
+/// The requirements' `maxStatementAge` as a duration. `None` when absent **or
+/// too large to represent** — a caller that must tell the two apart checks
+/// whether the member is set.
+#[must_use]
+pub fn max_statement_age(requirements: &VettingRequirements) -> Option<Duration> {
+    requirements
+        .max_statement_age
+        .as_deref()
+        .and_then(|d| parse_iso8601_duration(d))
 }
 
-/// `vetting/request/0.1` payload.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VettingRequestBody {
-    /// The community the applicant wants to be vetted for.
-    pub community: String,
-    /// `requirementsDigest` of the criterion the applicant is gathering for.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requirements_digest: Option<String>,
-    /// The DID the applicant will join with. MUST equal the document `issuer`.
-    pub join_did: String,
-    /// The vetter's ticket. Mutually exclusive with `introduction`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ticket: Option<TicketPresentation>,
-    /// A VIC for this community naming `joinDid`, used as a member
-    /// introduction. Mutually exclusive with `ticket`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub introduction: Option<Value>,
-    /// The method the applicant would prefer.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub preferred_method: Option<VettingMethod>,
-    /// BCP 47 language tags the applicant can be vetted in.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub languages: Vec<String>,
-    /// A short note to the vetter.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-    /// Free-text availability, for scheduling out of band.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub availability: Option<String>,
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<Value>,
-}
+// ---------------------------------------------------------------------------
+// Validation beyond the constructors
+// ---------------------------------------------------------------------------
 
-/// Why a payload breaks a rule its Trust Task schema states.
+/// Why a value breaks its specification.
 ///
-/// Serde checks member names and types. The bounds and patterns the schemas
-/// also set — lengths, the ticket-code alphabet, BCP 47 tags — are checked by
-/// each type's `check_shape`, which a receiver runs before acting on the
-/// payload and a sender before signing it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+/// A generated type's constructors check member names, types, patterns and
+/// lengths. [`ShapeError::Schema`] is everything else the published schema
+/// states; the other variants are the rules a schema cannot state.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
 pub enum ShapeError {
-    /// Both a ticket and an introduction were supplied.
-    #[error("a request carries a ticket or an introduction, not both")]
-    TicketAndIntroduction,
+    /// The value does not satisfy its published JSON Schema. Carries the
+    /// validator's messages.
+    #[error("breaks its published schema: {0}")]
+    Schema(String),
     /// `joinDid` differs from the document issuer.
     #[error("joinDid must be the document issuer")]
     JoinDidNotIssuer,
-    /// A member breaks its schema bound or pattern.
+    /// A member breaks a rule its specification states in prose.
     #[error("`{field}` {rule}")]
     Field {
         /// The member, spelled as on the wire.
@@ -551,161 +374,272 @@ pub enum ShapeError {
     },
 }
 
-impl VettingRequestBody {
-    /// Check the rules serde cannot: the schema's bounds and patterns, a ticket
-    /// or an introduction but not both, and `joinDid` = the document issuer.
-    ///
+/// Check a value against its specification: the schema the generated type
+/// embeds, plus the rules no JSON Schema can state. A receiver runs it before
+/// acting on a value, and a sender before signing one.
+pub trait CheckShape {
     /// # Errors
     ///
     /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self, document_issuer: &str) -> Result<(), ShapeError> {
-        if self.ticket.is_some() && self.introduction.is_some() {
-            return Err(ShapeError::TicketAndIntroduction);
-        }
-        if self.join_did != document_issuer {
-            return Err(ShapeError::JoinDidNotIssuer);
-        }
-        shape::did("community", &self.community)?;
-        shape::did("joinDid", &self.join_did)?;
-        match &self.ticket {
-            Some(TicketPresentation::Scanned { ticket_id, secret }) => {
-                shape::ticket_id("ticket.ticketId", ticket_id)?;
-                shape::base64url_32("ticket.secret", secret)?;
+    fn check_shape(&self) -> Result<(), ShapeError>;
+}
+
+fn schema_error(e: trust_tasks_rs::validate::ValidationError) -> ShapeError {
+    ShapeError::Schema(e.messages().join("; "))
+}
+
+/// Validate a generated payload or response against the schema its type embeds.
+fn against_own_schema<P: trust_tasks_rs::Payload + Serialize>(value: &P) -> Result<(), ShapeError> {
+    use trust_tasks_rs::validate::ValidatedPayload;
+    let json = serde_json::to_value(value).map_err(|e| ShapeError::Schema(e.to_string()))?;
+    P::validate_value(&json).map_err(schema_error)
+}
+
+/// Validate `json` against the definition `name` in the schema `P` embeds — for
+/// a value that travels inside a payload rather than as one: a card inside a
+/// session response, requirements inside a manifest.
+pub(crate) fn against_definition<P: trust_tasks_rs::Payload>(
+    name: &str,
+    json: &Value,
+) -> Result<(), ShapeError> {
+    let unavailable = |why: &str| ShapeError::Schema(format!("{}: {why}", P::TYPE_URI));
+    let embedded = P::PAYLOAD_SCHEMA.ok_or_else(|| unavailable("embeds no schema"))?;
+    let parsed: Value = serde_json::from_str(embedded).map_err(|e| unavailable(&e.to_string()))?;
+    let defs = parsed
+        .get("$defs")
+        .filter(|defs| defs.get(name).is_some())
+        .ok_or_else(|| unavailable(&format!("defines no `{name}`")))?;
+    let schema = serde_json::json!({
+        "$defs": defs,
+        "$ref": format!("#/$defs/{name}"),
+    });
+    trust_tasks_rs::validate::against_schema(&schema.to_string(), json).map_err(schema_error)
+}
+
+fn against_own_definition<P: trust_tasks_rs::Payload>(
+    name: &str,
+    value: &impl Serialize,
+) -> Result<(), ShapeError> {
+    let json = serde_json::to_value(value).map_err(|e| ShapeError::Schema(e.to_string()))?;
+    against_definition::<P>(name, &json)
+}
+
+/// Read a payload or response as received, and check it.
+///
+/// Validates `json` against the published schema **before** parsing it — some
+/// generated constructors normalise what they parse, so a value that has been
+/// through one no longer shows what was sent — then parses it and applies
+/// [`CheckShape`].
+///
+/// # Errors
+///
+/// [`ShapeError::Schema`] for JSON the schema refuses or that does not parse;
+/// otherwise the first rule [`CheckShape`] finds broken.
+pub fn read_checked<P>(json: &Value) -> Result<P, ShapeError>
+where
+    P: trust_tasks_rs::Payload + DeserializeOwned + CheckShape,
+{
+    use trust_tasks_rs::validate::ValidatedPayload;
+    P::validate_value(json).map_err(schema_error)?;
+    let parsed: P =
+        serde_json::from_value(json.clone()).map_err(|e| ShapeError::Schema(e.to_string()))?;
+    parsed.check_shape()?;
+    Ok(parsed)
+}
+
+/// Read a type defined inside another task's schema as received: validate
+/// `json` against the definition `name` of `C`'s schema, parse it, then apply
+/// [`CheckShape`].
+fn read_checked_definition<C, T>(name: &str, json: &Value) -> Result<T, ShapeError>
+where
+    C: trust_tasks_rs::Payload,
+    T: DeserializeOwned + CheckShape,
+{
+    against_definition::<C>(name, json)?;
+    let parsed: T =
+        serde_json::from_value(json.clone()).map_err(|e| ShapeError::Schema(e.to_string()))?;
+    parsed.check_shape()?;
+    Ok(parsed)
+}
+
+/// [`read_checked`] for a community's [`VettingRequirements`], as the join
+/// manifest 0.2 schema defines them.
+///
+/// # Errors
+///
+/// As [`read_checked`].
+pub fn read_requirements(json: &Value) -> Result<VettingRequirements, ShapeError> {
+    read_checked_definition::<manifest::Response, _>("VettingRequirements", json)
+}
+
+/// [`read_checked`] for a community's branding, as the join manifest 0.2
+/// schema defines it.
+///
+/// # Errors
+///
+/// As [`read_checked`].
+pub fn read_branding(json: &Value) -> Result<manifest::CommunityBranding, ShapeError> {
+    read_checked_definition::<manifest::Response, _>("CommunityBranding", json)
+}
+
+/// [`read_checked`] for a `vetting/request/0.1` payload, which also binds
+/// `joinDid` to the document issuer ([`check_request`]).
+///
+/// # Errors
+///
+/// As [`read_checked`], or [`ShapeError::JoinDidNotIssuer`].
+pub fn read_request(
+    json: &Value,
+    document_issuer: &str,
+) -> Result<request::v0_1::Payload, ShapeError> {
+    use trust_tasks_rs::validate::ValidatedPayload;
+    request::v0_1::Payload::validate_value(json).map_err(schema_error)?;
+    let parsed: request::v0_1::Payload =
+        serde_json::from_value(json.clone()).map_err(|e| ShapeError::Schema(e.to_string()))?;
+    check_request(&parsed, document_issuer)?;
+    Ok(parsed)
+}
+
+/// Tasks whose schema is the whole rule.
+macro_rules! checked_by_schema {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl CheckShape for $ty {
+                fn check_shape(&self) -> Result<(), ShapeError> {
+                    against_own_schema(self)
+                }
             }
-            Some(TicketPresentation::Code { code }) => shape::ticket_code("ticket.code", code)?,
-            None => {}
-        }
-        shape::languages("languages", &self.languages)?;
-        shape::optional_length("message", self.message.as_deref(), 1000)?;
-        shape::optional_length("availability", self.availability.as_deref(), 256)
+        )+
+    };
+}
+
+checked_by_schema!(
+    request::v0_1::Response,
+    session::v0_1::Payload,
+    session::v0_1::Response,
+    decline::v0_1::Payload,
+    revoke_statement::v0_1::Payload,
+    revoke_statement::v0_1::Response,
+    vetters::grant::v0_1::Payload,
+    vetters::grant::v0_1::Response,
+    vetters::profile::v0_1::Response,
+    vetters::list::v0_1::Response,
+    vetters::resend::v0_1::Payload,
+    vetters::resend::v0_1::Response,
+);
+
+/// Check a `vetting/request/0.1` payload: its schema — a ticket or an
+/// introduction but not both, the ticket's patterns, the bounds — and that
+/// `joinDid` is the document issuer, which no schema can see.
+///
+/// # Errors
+///
+/// [`ShapeError`] for the first rule broken.
+pub fn check_request(
+    payload: &request::v0_1::Payload,
+    document_issuer: &str,
+) -> Result<(), ShapeError> {
+    against_own_schema(payload)?;
+    if payload.join_did.as_str() != document_issuer {
+        return Err(ShapeError::JoinDidNotIssuer);
+    }
+    Ok(())
+}
+
+impl CheckShape for session::v0_1::VettingCard {
+    /// The card definition the session response carries. The proof is shaped
+    /// here, not verified: `crate::vetting::card` verifies it.
+    fn check_shape(&self) -> Result<(), ShapeError> {
+        against_own_definition::<session::v0_1::Response>("VettingCard", self)
     }
 }
 
-/// `vetting/request/0.1#response` payload — the vetter accepted.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VettingRequestAcceptedBody {
-    /// The vetter's handle for this request; every later task names it.
-    pub request_id: String,
-    /// A VP of the vetter's community-issued VMC and `vetter` role VEC, with the
-    /// `vetting/request` document's `id` as its challenge — a value the
-    /// applicant chose, so the proof is fresh — letting the applicant confirm
-    /// eligibility before investing in a session.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub eligibility_vp: Option<Value>,
-    /// The documentation this vetter accepts (their own choice, D16).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub accepts_documentation: Vec<String>,
-    /// Free text: how the vetter proposes to meet.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session_hint: Option<String>,
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<Value>,
+impl CheckShape for vetters::profile::v0_1::Payload {
+    fn check_shape(&self) -> Result<(), ShapeError> {
+        against_own_schema(self)?;
+        // `VetterEvent`: "`endDate` is on or after `startDate` and no more than
+        // 31 days after it; JSON Schema cannot compare two members, so the
+        // community checks both".
+        for event in &self.events {
+            let (start, end) = (event.start_date.0, event.end_date.0);
+            if end < start {
+                return Err(ShapeError::Field {
+                    field: "events.endDate",
+                    rule: "must not be before startDate",
+                });
+            }
+            if (end - start).num_days() > MAX_VETTER_EVENT_SPAN_DAYS {
+                return Err(ShapeError::Field {
+                    field: "events.endDate",
+                    rule: "must be at most 31 days after startDate",
+                });
+            }
+        }
+        Ok(())
+    }
 }
 
-// ---------------------------------------------------------------------------
-// vetting/session/0.1
-// ---------------------------------------------------------------------------
-
-/// `vetting/session/0.1` payload. The vetter sends it when both people are
-/// together. The document's `id` is the session's name: both clients derive
-/// the match code from it, and the statement carries it as `taskContext`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VettingSessionBody {
-    /// The accepted request this session belongs to.
-    pub request_id: String,
-    /// Single-use challenge the card must carry. base64url, 32 bytes.
-    pub challenge: String,
-    /// Binding domain the card must carry — the community DID.
-    pub domain: String,
-    /// The method this session uses.
-    pub method: VettingMethod,
-    /// Claim types the card must carry.
-    pub required_claims: Vec<String>,
-    /// Claim types the card may carry.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub optional_claims: Vec<String>,
-    /// After this the applicant's client refuses to present.
-    pub expires_at: DateTime<Utc>,
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<Value>,
+impl CheckShape for vetters::list::v0_1::Payload {
+    fn check_shape(&self) -> Result<(), ShapeError> {
+        against_own_schema(self)?;
+        // Conformance 1: a request whose `eventFrom` is after its `eventTo` is
+        // refused with `malformedRequest`.
+        if let (Some(from), Some(to)) = (&self.event_from, &self.event_to)
+            && to.0 < from.0
+        {
+            return Err(ShapeError::Field {
+                field: "eventTo",
+                rule: "must not be before eventFrom",
+            });
+        }
+        Ok(())
+    }
 }
 
-/// `vetting/session/0.1#response` payload.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VettingSessionResponseBody {
-    /// The signed Vetting Card, exactly as signed.
-    pub card: Value,
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<Value>,
+impl CheckShape for VettingRequirements {
+    /// A community refuses to publish requirements that fail this, and a client
+    /// treats a criterion that fails it as unsatisfiable rather than guess
+    /// (`vtc/join-requests/manifest/0.2`, Conformance 3).
+    fn check_shape(&self) -> Result<(), ShapeError> {
+        against_own_definition::<manifest::Response>("VettingRequirements", self)?;
+        if self
+            .min_by_method
+            .keys()
+            .any(|method| !self.accepted_methods.contains(method))
+        {
+            return Err(ShapeError::Field {
+                field: "minByMethod",
+                rule: "names a method acceptedMethods does not accept",
+            });
+        }
+        Ok(())
+    }
 }
 
-// ---------------------------------------------------------------------------
-// The Vetting Card (a VDS)
-// ---------------------------------------------------------------------------
-
-/// One claim on a Vetting Card.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct CardClaim {
-    /// Claim type from the claim-type registry, e.g. `name.legal`.
-    #[serde(rename = "type")]
-    pub claim_type: String,
-    /// The claim value.
-    pub value: Value,
-    /// Where the value came from — `selfAsserted` in V0.
-    pub provenance: String,
+impl CheckShape for manifest::CommunityBranding {
+    fn check_shape(&self) -> Result<(), ShapeError> {
+        against_own_definition::<manifest::Response>("CommunityBranding", self)
+    }
 }
 
-/// A Vetting Card: an r-card profile, signed by the applicant's join DID and
-/// bound to one vetter and one session. Carries no document numbers, images or
-/// portraits.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VettingCard {
-    /// [`VETTING_CARD_TYPES`].
-    #[serde(rename = "type")]
-    pub types: Vec<String>,
-    /// `urn:uuid:…`.
-    pub id: String,
-    /// The applicant's join DID — the signer.
-    pub publisher: String,
-    /// r-card version.
-    pub card_version: u32,
-    /// The one vetter this card is for.
-    pub audience: String,
-    /// The community the vetting is for.
-    pub community: String,
-    /// From the session.
-    pub challenge: String,
-    /// From the session.
-    pub domain: String,
-    /// When the card was made.
-    pub issued_at: DateTime<Utc>,
-    /// When it stops being presentable.
-    pub expires_at: DateTime<Utc>,
-    /// The claims shown to the vetter.
-    pub claims: Vec<CardClaim>,
-    /// Salted digest over the identity claims; equal on every card of one
-    /// application.
-    pub identity_commitment: String,
-    /// The per-application salt — disclosed to vetters, never to the community.
-    pub commitment_salt: String,
-    /// Data Integrity proof by `publisher`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub proof: Option<Value>,
+/// Is `vetters::list::v0_1::Payload` filtering on events at all: a date bound
+/// or a name?
+#[must_use]
+pub fn has_event_filter(body: &vetters::list::v0_1::Payload) -> bool {
+    body.event_from.is_some() || body.event_to.is_some() || body.event_name.is_some()
 }
 
 // ---------------------------------------------------------------------------
 // The Vetting Statement's endorsement body
 // ---------------------------------------------------------------------------
 
-/// `credentialSubject.endorsement` of a Vetting Statement.
+/// `credentialSubject.endorsement` of a Vetting Statement —
+/// `vetting/_shared/0.1/identity-vetting`.
+///
+/// Written here because nothing generates it: it is a credential body, not a
+/// Trust Task, and the codegen skips shared definitions. Its members take the
+/// generated vocabulary, so a statement and the requirements it is counted
+/// against compare value for value.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct IdentityVettingEndorsement {
@@ -717,11 +651,11 @@ pub struct IdentityVettingEndorsement {
     /// How the vetter established identity.
     pub method: VettingMethod,
     /// What the vetter relied on, from their own accepted list; empty with
-    /// `priorAcquaintance`.
+    /// `priorAcquaintance`. Never `none`: no document is the empty list.
     #[serde(default)]
-    pub document_classes: Vec<String>,
+    pub document_classes: Vec<VettingDocumentation>,
     /// Claim types the vetter verified.
-    pub claims_verified: Vec<String>,
+    pub claims_verified: Vec<ClaimType>,
     /// The match code was confirmed with the person present.
     pub liveness_confirmed: bool,
     /// Copied from the card.
@@ -729,403 +663,54 @@ pub struct IdentityVettingEndorsement {
     /// `digestMultibase` of the card the vetter checked.
     pub card_digest_multibase: String,
     /// The vetter's declared relationship to the applicant.
-    pub declared_relationship: DeclaredRelationship,
+    pub declared_relationship: VettingRelationship,
     /// `digestMultibase` of the attestation text the vetter was shown.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attestation_text_digest: Option<String>,
 }
 
-// ---------------------------------------------------------------------------
-// vetting/decline/0.1
-// ---------------------------------------------------------------------------
-
-/// Why a vetter declined. Optional — a vetter never has to say.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub enum DeclineCode {
-    /// The vetter could not establish identity.
-    CouldNotVerify,
-    /// The documentation did not match the card.
-    DocumentMismatch,
-    /// The match code could not be confirmed with the person.
-    LivenessFailed,
-    /// The vetter is not comfortable attesting.
-    NotComfortable,
-    /// Something else.
-    Other,
-}
-
-/// `vetting/decline/0.1` payload. Declines are never sent to the community.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VettingDeclineBody {
-    /// The request being declined.
-    pub request_id: String,
-    /// Optional reason code.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub code: Option<DeclineCode>,
-    /// Optional note to the applicant.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<Value>,
-}
-
-// ---------------------------------------------------------------------------
-// vtc/vetting/revoke-statement/0.1
-// ---------------------------------------------------------------------------
-
-/// Why a vetter withdrew a statement.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub enum RevocationReason {
-    /// The vetter made a mistake.
-    Mistake,
-    /// The vetter learned something new.
-    NewInformation,
-    /// The vetter's signing key was compromised.
-    KeyCompromise,
-    /// Something else.
-    Other,
-}
-
-/// `vtc/vetting/revoke-statement/0.1` payload.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct RevokeStatementBody {
-    /// The statement's `id`.
-    pub statement_id: String,
-    /// `digestMultibase` of the statement, so a notice cannot be aimed at a
-    /// different credential that reused the id.
-    pub statement_digest_multibase: String,
-    /// Optional reason; shared with the applicant only if the vetter chooses.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reason: Option<RevocationReason>,
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<Value>,
-}
-
-/// `vtc/vetting/revoke-statement/0.1#response` payload.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct RevokeStatementResponseBody {
-    /// When the community recorded the notice. Repeating a notice returns the
-    /// original time: revocation converges.
-    pub recorded_at: DateTime<Utc>,
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<Value>,
-}
-
-// ---------------------------------------------------------------------------
-// vtc/vetting/vetters/grant/0.1
-// ---------------------------------------------------------------------------
-
-/// Shortest vetter grant a community may issue: one day.
-pub const MIN_VETTER_GRANT_VALIDITY_SECONDS: u64 = 86_400;
-/// Longest vetter grant a community may issue: two years.
-pub const MAX_VETTER_GRANT_VALIDITY_SECONDS: u64 = 2 * 365 * 86_400;
-/// A grant's validity when the request names none: one year.
-pub const DEFAULT_VETTER_GRANT_VALIDITY_SECONDS: u64 = 365 * 86_400;
-
-/// `vtc/vetting/vetters/grant/0.1` payload.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VetterGrantBody {
-    /// The member to name as a vetter.
-    pub member_did: String,
-    /// How long the grant is valid, from one day to two years; one year when
-    /// absent.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub validity_seconds: Option<u64>,
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<Value>,
-}
-
-/// `vtc/vetting/vetters/grant/0.1#response` payload.
-///
-/// Granting converges: while a grant is live and unexpired, asking again
-/// returns it rather than issuing a second.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VetterGrantResponseBody {
-    /// The community's record of the grant — the id its revocation names.
-    pub endorsement_id: String,
-    /// The vetter role credential's `id`.
-    pub credential_id: String,
-    /// The credential's `validFrom`.
-    pub valid_from: DateTime<Utc>,
-    /// The credential's `validUntil`.
-    pub valid_until: DateTime<Utc>,
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<Value>,
-}
-
-// ---------------------------------------------------------------------------
-// vtc/vetting/vetters/profile/0.1
-// ---------------------------------------------------------------------------
-
-/// Longest `displayName`, `region` or `city`.
-pub const MAX_VETTER_NAME_CHARS: usize = 128;
-/// Most `languages` a profile lists.
-pub const MAX_VETTER_LANGUAGES: usize = 16;
-/// Most `methods` a profile lists (there are three).
-pub const MAX_VETTER_METHODS: usize = 3;
-/// Most `acceptsDocumentation` tokens a profile lists.
-pub const MAX_VETTER_ACCEPTED_DOCUMENTATION: usize = 16;
-/// Longest `availability`.
-pub const MAX_VETTER_AVAILABILITY_CHARS: usize = 500;
-/// Longest `contactHint`.
-pub const MAX_VETTER_CONTACT_HINT_CHARS: usize = 300;
-/// Most `events` a profile lists.
-pub const MAX_VETTER_EVENTS: usize = 32;
-/// Longest event `name`, and the longest `eventName` filter.
-pub const MAX_VETTER_EVENT_NAME_CHARS: usize = 200;
-/// Longest span of one event, `endDate − startDate`, in days.
-pub const MAX_VETTER_EVENT_SPAN_DAYS: i64 = 31;
-/// Longest event `url` and branding `logoUrl`.
-pub const MAX_VETTING_URL_CHARS: usize = 2048;
-
-/// Where a vetter is, or where an event is held.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VetterLocation {
-    /// ISO 3166-1 alpha-2, uppercase.
-    pub country: String,
-    /// Region, state or province; 1–128 characters.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub region: Option<String>,
-    /// City; 1–128 characters.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub city: Option<String>,
-}
-
-/// An event a vetter will attend and vet at — a conference, a summit.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VetterEvent {
-    /// The event's name; 1–200 characters.
-    pub name: String,
-    /// First day, `YYYY-MM-DD`.
-    #[serde(with = "date_only")]
-    #[cfg_attr(feature = "openapi", schema(value_type = String, format = Date))]
-    pub start_date: NaiveDate,
-    /// Last day, `YYYY-MM-DD`; not before `startDate`, at most 31 days after it.
-    #[serde(with = "date_only")]
-    #[cfg_attr(feature = "openapi", schema(value_type = String, format = Date))]
-    pub end_date: NaiveDate,
-    /// Where it is held.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub location: Option<VetterLocation>,
-    /// The event's page; `https`, at most 2048 characters.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-}
-
-/// `vtc/vetting/vetters/profile/0.1` payload. Replaces the whole profile.
-///
-/// `languages`, `methods`, `acceptsDocumentation` and `events` are required,
-/// and may be empty — all but `methods`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VetterProfileBody {
-    /// `false` keeps the profile but removes it from listings.
-    pub listed: bool,
-    /// How the vetter wants to be named; 1–128 characters.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub display_name: Option<String>,
-    /// BCP 47 tags the vetter can vet in, most preferred first; at most 16.
-    pub languages: Vec<String>,
-    /// Where the vetter is.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub location: Option<VetterLocation>,
-    /// The methods the vetter offers; one to three, no repeats.
-    pub methods: Vec<VettingMethod>,
-    /// The documentation this vetter accepts — their own choice (D16); at most
-    /// 16 distinct tokens, as in `vetting/request#response`.
-    pub accepts_documentation: Vec<String>,
-    /// Free-text availability; 1–500 characters.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub availability: Option<String>,
-    /// How to get a ticket from this vetter; 1–300 characters. A request still
-    /// needs a ticket.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub contact_hint: Option<String>,
-    /// Events the vetter will vet at; at most 32.
-    pub events: Vec<VetterEvent>,
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<Value>,
-}
-
-/// `vtc/vetting/vetters/profile/0.1#response` payload.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VetterProfileResponseBody {
-    /// The `listed` the community stored.
-    pub listed: bool,
-    /// When the community stored the profile.
-    pub updated_at: DateTime<Utc>,
-}
-
-// ---------------------------------------------------------------------------
-// vtc/vetting/vetters/list/0.1
-// ---------------------------------------------------------------------------
-
-/// A listing page when the request names no `limit`.
-pub const DEFAULT_VETTER_LIST_LIMIT: u32 = 50;
-/// The largest listing page.
-pub const MAX_VETTER_LIST_LIMIT: u32 = 100;
-/// Longest listing `cursor`.
-pub const MAX_VETTER_LIST_CURSOR_CHARS: usize = 512;
-
-/// `vtc/vetting/vetters/list/0.1` payload. Every filter is optional; filters
-/// combine with AND.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VetterListBody {
-    /// A BCP 47 tag. Matches a listed tag equal to it, or one it is a prefix of
-    /// at a subtag boundary (`de` matches `de-AT`). Compared case-insensitively.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub language: Option<String>,
-    /// ISO 3166-1 alpha-2, uppercase.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub country: Option<String>,
-    /// Case-insensitive exact match on `location.region`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub region: Option<String>,
-    /// Case-insensitive exact match on `location.city`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub city: Option<String>,
-    /// A method the vetter offers.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub method: Option<VettingMethod>,
-    /// With `eventTo`, a date range a listed event must overlap; an open end is
-    /// unbounded.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "optional_date_only"
-    )]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, format = Date))]
-    pub event_from: Option<NaiveDate>,
-    /// See [`Self::event_from`].
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "optional_date_only"
-    )]
-    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, format = Date))]
-    pub event_to: Option<NaiveDate>,
-    /// Case-insensitive substring of a listed event's name; at most 200
-    /// characters.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub event_name: Option<String>,
-    /// Page size, 1–100; 50 when absent.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub limit: Option<u32>,
-    /// The `nextCursor` of the previous page; at most 512 characters.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cursor: Option<String>,
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<Value>,
-}
-
-impl VetterListBody {
-    /// Whether the request filters on events at all: a date bound or a name.
-    #[must_use]
-    pub fn has_event_filter(&self) -> bool {
-        self.event_from.is_some() || self.event_to.is_some() || self.event_name.is_some()
+impl CheckShape for IdentityVettingEndorsement {
+    /// The shared definition's rules beyond what the member types enforce. No
+    /// schema for it is embedded anywhere, so they are checked here.
+    fn check_shape(&self) -> Result<(), ShapeError> {
+        if self.endorsement_type.is_empty() || self.endorsement_type.chars().count() > 512 {
+            return Err(ShapeError::Field {
+                field: "type",
+                rule: "is empty or longer than 512 characters",
+            });
+        }
+        shape::did("community", &self.community)?;
+        if shape::repeats(&self.document_classes) {
+            return Err(ShapeError::Field {
+                field: "documentClasses",
+                rule: "repeats a documentation class",
+            });
+        }
+        if self
+            .document_classes
+            .iter()
+            .any(|d| d.as_str() == documentation::NONE)
+        {
+            return Err(ShapeError::Field {
+                field: "documentClasses",
+                rule: "never lists `none`: no document is the empty list",
+            });
+        }
+        if shape::repeats(&self.claims_verified) {
+            return Err(ShapeError::Field {
+                field: "claimsVerified",
+                rule: "repeats a claim type",
+            });
+        }
+        shape::no_portrait(
+            "claimsVerified",
+            self.claims_verified.iter().map(|c| c.as_str()),
+        )
     }
 }
 
-/// One vetter in a listing: the published profile, the DID and the grant's
-/// expiry — nothing else about the member.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct ListedVetter {
-    /// The vetter's DID — where a `vetting/request` goes.
-    pub vetter_did: String,
-    /// See [`VetterProfileBody::display_name`].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub display_name: Option<String>,
-    /// See [`VetterProfileBody::languages`].
-    pub languages: Vec<String>,
-    /// See [`VetterProfileBody::location`].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub location: Option<VetterLocation>,
-    /// See [`VetterProfileBody::methods`].
-    pub methods: Vec<VettingMethod>,
-    /// See [`VetterProfileBody::accepts_documentation`].
-    pub accepts_documentation: Vec<String>,
-    /// See [`VetterProfileBody::availability`].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub availability: Option<String>,
-    /// See [`VetterProfileBody::contact_hint`].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub contact_hint: Option<String>,
-    /// The profile's events that have not ended (`endDate` ≥ today, UTC).
-    pub events: Vec<VetterEvent>,
-    /// When the vetter's grant expires.
-    pub grant_valid_until: DateTime<Utc>,
-    /// When the profile was last published.
-    pub updated_at: DateTime<Utc>,
-}
-
-/// `vtc/vetting/vetters/list/0.1#response` payload.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VetterListResponseBody {
-    /// This page, in the listing's order.
-    pub vetters: Vec<ListedVetter>,
-    /// Pass as `cursor`, with the same filters, for the next page; absent on
-    /// the last.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub next_cursor: Option<String>,
-}
-
 // ---------------------------------------------------------------------------
-// vtc/vetting/vetters/resend/0.1
-// ---------------------------------------------------------------------------
-
-/// `vtc/vetting/vetters/resend/0.1` payload: nothing but `ext`. The sender is
-/// the vetter whose grant is re-delivered.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VetterResendBody {
-    /// Ecosystem-defined extension members (SPEC §4.5.1).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ext: Option<Value>,
-}
-
-/// `vtc/vetting/vetters/resend/0.1#response` payload — also the answer to the
-/// admin `POST /v1/vetting/vetters/{memberDid}/resend`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VetterResendResponseBody {
-    /// The re-delivered credential's `id`.
-    pub credential_id: String,
-    /// Its `validUntil`.
-    pub valid_until: DateTime<Utc>,
-}
-
-// ---------------------------------------------------------------------------
-// VTC admin REST: vetter grants and automatic grants
+// VTC admin REST: vetter grants and automatic grants. Not Trust Tasks.
 // ---------------------------------------------------------------------------
 
 /// Who issued a vetter grant.
@@ -1158,7 +743,11 @@ pub struct VetterProfileSummary {
     pub languages: Vec<String>,
     /// The profile's `methods`.
     #[serde(default)]
-    pub methods: Vec<VettingMethod>,
+    #[cfg_attr(
+        feature = "openapi",
+        schema(value_type = Vec<crate::openapi::VetterProfile01VettingMethod>)
+    )]
+    pub methods: Vec<vetters::profile::v0_1::VettingMethod>,
     /// How many events the profile lists, ended or not.
     pub event_count: u32,
     /// When the profile was last published.
@@ -1228,13 +817,8 @@ pub struct AutoGrantConfig {
     pub validity_seconds: Option<u64>,
 }
 
-impl AutoGrantConfig {
-    /// Check the bounds.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), ShapeError> {
+impl CheckShape for AutoGrantConfig {
+    fn check_shape(&self) -> Result<(), ShapeError> {
         if self.sweep_minutes.is_some_and(|m| {
             !(MIN_AUTO_GRANT_SWEEP_MINUTES..=MAX_AUTO_GRANT_SWEEP_MINUTES).contains(&m)
         }) {
@@ -1286,557 +870,29 @@ pub struct AutoGrantStatus {
     pub last_sweep: Option<AutoGrantSweep>,
 }
 
-/// `YYYY-MM-DD`, exactly: four-digit year, two-digit month and day.
-mod date_only {
-    use chrono::NaiveDate;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub(super) const FORMAT: &str = "%Y-%m-%d";
-
-    pub(super) fn parse(s: &str) -> Option<NaiveDate> {
-        let b = s.as_bytes();
-        let shaped = b.len() == 10
-            && b[4] == b'-'
-            && b[7] == b'-'
-            && b.iter()
-                .enumerate()
-                .all(|(i, c)| i == 4 || i == 7 || c.is_ascii_digit());
-        if !shaped {
-            return None;
-        }
-        NaiveDate::parse_from_str(s, FORMAT).ok()
-    }
-
-    pub(super) fn serialize<S: Serializer>(date: &NaiveDate, s: S) -> Result<S::Ok, S::Error> {
-        s.serialize_str(&date.format(FORMAT).to_string())
-    }
-
-    pub(super) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<NaiveDate, D::Error> {
-        let s = String::deserialize(d)?;
-        parse(&s).ok_or_else(|| serde::de::Error::custom("a date must be YYYY-MM-DD"))
-    }
-}
-
-/// [`date_only`] for an optional member.
-mod optional_date_only {
-    use chrono::NaiveDate;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    #[allow(clippy::ref_option)] // serde's `with` hands serializers `&Option<T>`
-    pub(super) fn serialize<S: Serializer>(
-        date: &Option<NaiveDate>,
-        s: S,
-    ) -> Result<S::Ok, S::Error> {
-        match date {
-            Some(d) => super::date_only::serialize(d, s),
-            None => s.serialize_none(),
-        }
-    }
-
-    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
-        d: D,
-    ) -> Result<Option<NaiveDate>, D::Error> {
-        let s = String::deserialize(d)?;
-        super::date_only::parse(&s)
-            .map(Some)
-            .ok_or_else(|| serde::de::Error::custom("a date must be YYYY-MM-DD"))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Shape checks for the remaining payloads
-// ---------------------------------------------------------------------------
-
-/// The claim type a card, session or statement must never name: portraits are
-/// not carried (design D17).
-pub const PORTRAIT_CLAIM_TYPE: &str = "person.portrait";
-
-impl VettingRequestAcceptedBody {
-    /// Check the schema's bounds and patterns.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), ShapeError> {
-        shape::length("requestId", &self.request_id, 128)?;
-        shape::tokens("acceptsDocumentation", &self.accepts_documentation)?;
-        shape::optional_length("sessionHint", self.session_hint.as_deref(), 500)
-    }
-}
-
-impl VettingSessionBody {
-    /// Check the schema's bounds and patterns.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), ShapeError> {
-        shape::length("requestId", &self.request_id, 128)?;
-        shape::base64url_32("challenge", &self.challenge)?;
-        shape::did("domain", &self.domain)?;
-        shape::no_portrait(
-            "requiredClaims",
-            self.required_claims.iter().map(String::as_str),
-        )?;
-        shape::no_portrait(
-            "optionalClaims",
-            self.optional_claims.iter().map(String::as_str),
-        )
-    }
-}
-
-impl VettingCard {
-    /// Check the schema's bounds and patterns. The proof is not checked here:
-    /// a card is shaped before it is signed, and verification checks the proof.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), ShapeError> {
-        if self.types.len() != VETTING_CARD_TYPES.len()
-            || !VETTING_CARD_TYPES
-                .iter()
-                .all(|t| self.types.iter().any(|s| s == t))
-        {
-            return Err(ShapeError::Field {
-                field: "type",
-                rule: "must be exactly VerifiableDataStructure, RelationshipCard and VettingCard",
-            });
-        }
-        shape::did("publisher", &self.publisher)?;
-        shape::did("audience", &self.audience)?;
-        shape::did("community", &self.community)?;
-        shape::did("domain", &self.domain)?;
-        shape::base64url_32("challenge", &self.challenge)?;
-        shape::base64url_32("commitmentSalt", &self.commitment_salt)?;
-        if self.claims.is_empty() {
-            return Err(ShapeError::Field {
-                field: "claims",
-                rule: "must carry at least one claim",
-            });
-        }
-        for claim in &self.claims {
-            shape::token("claims.provenance", &claim.provenance)?;
-        }
-        shape::no_portrait(
-            "claims.type",
-            self.claims.iter().map(|c| c.claim_type.as_str()),
-        )
-    }
-}
-
-impl IdentityVettingEndorsement {
-    /// Check the schema's bounds and patterns.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), ShapeError> {
-        shape::did("community", &self.community)?;
-        shape::tokens("documentClasses", &self.document_classes)?;
-        shape::no_portrait(
-            "claimsVerified",
-            self.claims_verified.iter().map(String::as_str),
-        )
-    }
-}
-
-impl VettingDeclineBody {
-    /// Check the schema's bounds and patterns.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), ShapeError> {
-        shape::length("requestId", &self.request_id, 128)?;
-        shape::optional_length("message", self.message.as_deref(), 500)
-    }
-}
-
-impl RevokeStatementBody {
-    /// Check the schema's bounds and patterns.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), ShapeError> {
-        shape::statement_id("statementId", &self.statement_id)
-    }
-}
-
-impl VetterGrantBody {
-    /// Check the schema's bounds and patterns.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), ShapeError> {
-        shape::did("memberDid", &self.member_did)?;
-        match self.validity_seconds {
-            Some(s)
-                if !(MIN_VETTER_GRANT_VALIDITY_SECONDS..=MAX_VETTER_GRANT_VALIDITY_SECONDS)
-                    .contains(&s) =>
-            {
-                Err(ShapeError::Field {
-                    field: "validitySeconds",
-                    rule: "must be between one day and two years",
-                })
-            }
-            _ => Ok(()),
-        }
-    }
-}
-
-impl VetterLocation {
-    /// Check the schema's bounds and patterns.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), ShapeError> {
-        shape::country("location.country", &self.country)?;
-        shape::optional_length(
-            "location.region",
-            self.region.as_deref(),
-            MAX_VETTER_NAME_CHARS,
-        )?;
-        shape::optional_length("location.city", self.city.as_deref(), MAX_VETTER_NAME_CHARS)
-    }
-}
-
-impl VetterEvent {
-    /// Check the schema's bounds and patterns.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), ShapeError> {
-        shape::length("events.name", &self.name, MAX_VETTER_EVENT_NAME_CHARS)?;
-        if self.end_date < self.start_date {
-            return Err(ShapeError::Field {
-                field: "events.endDate",
-                rule: "must not be before startDate",
-            });
-        }
-        if (self.end_date - self.start_date).num_days() > MAX_VETTER_EVENT_SPAN_DAYS {
-            return Err(ShapeError::Field {
-                field: "events.endDate",
-                rule: "must be at most 31 days after startDate",
-            });
-        }
-        if let Some(location) = &self.location {
-            location.check_shape()?;
-        }
-        match &self.url {
-            Some(url) => shape::https_url("events.url", url, MAX_VETTING_URL_CHARS),
-            None => Ok(()),
-        }
-    }
-}
-
-impl VetterProfileBody {
-    /// Check the schema's bounds and patterns.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), ShapeError> {
-        shape::optional_length(
-            "displayName",
-            self.display_name.as_deref(),
-            MAX_VETTER_NAME_CHARS,
-        )?;
-        shape::languages("languages", &self.languages)?;
-        if let Some(location) = &self.location {
-            location.check_shape()?;
-        }
-        if self.methods.is_empty() || self.methods.len() > MAX_VETTER_METHODS {
-            return Err(ShapeError::Field {
-                field: "methods",
-                rule: "must list one to three methods",
-            });
-        }
-        if self
-            .methods
-            .iter()
-            .enumerate()
-            .any(|(i, m)| self.methods[..i].contains(m))
-        {
-            return Err(ShapeError::Field {
-                field: "methods",
-                rule: "repeats a method",
-            });
-        }
-        if self.accepts_documentation.len() > MAX_VETTER_ACCEPTED_DOCUMENTATION {
-            return Err(ShapeError::Field {
-                field: "acceptsDocumentation",
-                rule: "lists more than 16 documentation tokens",
-            });
-        }
-        shape::tokens("acceptsDocumentation", &self.accepts_documentation)?;
-        if self
-            .accepts_documentation
-            .iter()
-            .enumerate()
-            .any(|(i, d)| self.accepts_documentation[..i].contains(d))
-        {
-            return Err(ShapeError::Field {
-                field: "acceptsDocumentation",
-                rule: "repeats a documentation token",
-            });
-        }
-        shape::optional_length(
-            "availability",
-            self.availability.as_deref(),
-            MAX_VETTER_AVAILABILITY_CHARS,
-        )?;
-        shape::optional_length(
-            "contactHint",
-            self.contact_hint.as_deref(),
-            MAX_VETTER_CONTACT_HINT_CHARS,
-        )?;
-        if self.events.len() > MAX_VETTER_EVENTS {
-            return Err(ShapeError::Field {
-                field: "events",
-                rule: "lists more than 32 events",
-            });
-        }
-        self.events.iter().try_for_each(VetterEvent::check_shape)
-    }
-}
-
-impl VetterListBody {
-    /// Check the schema's bounds and patterns.
-    ///
-    /// # Errors
-    ///
-    /// [`ShapeError`] for the first rule broken.
-    pub fn check_shape(&self) -> Result<(), ShapeError> {
-        if let Some(language) = &self.language
-            && !shape::language_tag(language)
-        {
-            return Err(ShapeError::Field {
-                field: "language",
-                rule: "must be a BCP 47 language tag",
-            });
-        }
-        if let Some(country) = &self.country {
-            shape::country("country", country)?;
-        }
-        shape::optional_length("region", self.region.as_deref(), MAX_VETTER_NAME_CHARS)?;
-        shape::optional_length("city", self.city.as_deref(), MAX_VETTER_NAME_CHARS)?;
-        if let (Some(from), Some(to)) = (self.event_from, self.event_to)
-            && to < from
-        {
-            return Err(ShapeError::Field {
-                field: "eventTo",
-                rule: "must not be before eventFrom",
-            });
-        }
-        shape::optional_length(
-            "eventName",
-            self.event_name.as_deref(),
-            MAX_VETTER_EVENT_NAME_CHARS,
-        )?;
-        if self
-            .limit
-            .is_some_and(|l| !(1..=MAX_VETTER_LIST_LIMIT).contains(&l))
-        {
-            return Err(ShapeError::Field {
-                field: "limit",
-                rule: "must be between 1 and 100",
-            });
-        }
-        shape::optional_length(
-            "cursor",
-            self.cursor.as_deref(),
-            MAX_VETTER_LIST_CURSOR_CHARS,
-        )
-    }
-}
-
-/// The bounds and patterns the vetting schemas set, written out rather than
-/// compiled from regular expressions so the crate takes no regex dependency.
-/// Each function names the schema pattern it implements. Crate-visible so
-/// `crate::vetting::ticket_uri` checks a decoded ticket with the same rules.
+/// The rules a schema does not carry for the values checked by hand here.
+/// Crate-visible so `crate::vetting::ticket_uri` checks a decoded ticket's
+/// vetter with the same rule.
 pub(crate) mod shape {
     use super::{PORTRAIT_CLAIM_TYPE, ShapeError};
 
-    /// Crockford base32: no `I`, `L`, `O` or `U` (`[0-9A-HJKMNP-TV-Z]`).
-    const CROCKFORD: &[u8] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
-
-    fn fail(field: &'static str, rule: &'static str) -> Result<(), ShapeError> {
-        Err(ShapeError::Field { field, rule })
-    }
-
-    /// `minLength: 1`, `maxLength: max`, counted in characters as JSON Schema
-    /// counts them.
-    pub(crate) fn length(field: &'static str, value: &str, max: usize) -> Result<(), ShapeError> {
-        let n = value.chars().count();
-        if n == 0 || n > max {
-            return fail(field, "is empty or longer than its schema allows");
-        }
-        Ok(())
-    }
-
-    pub(crate) fn optional_length(
-        field: &'static str,
-        value: Option<&str>,
-        max: usize,
-    ) -> Result<(), ShapeError> {
-        value.map_or(Ok(()), |v| length(field, v, max))
-    }
-
-    /// `^did:`.
+    /// `^did:` — the pattern every vetting schema gives a DID.
     pub(crate) fn did(field: &'static str, value: &str) -> Result<(), ShapeError> {
-        if value.len() > "did:".len() && value.starts_with("did:") {
+        if value.starts_with("did:") {
             return Ok(());
         }
-        fail(field, "must be a DID")
-    }
-
-    /// `^[A-Za-z0-9_-]{43}$` — 32 bytes, base64url without padding.
-    pub(crate) fn base64url_32(field: &'static str, value: &str) -> Result<(), ShapeError> {
-        if value.len() == 43
-            && value
-                .bytes()
-                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
-        {
-            return Ok(());
-        }
-        fail(field, "must be 32 bytes, base64url without padding")
-    }
-
-    /// `^[a-z][a-zA-Z0-9]*$`, at most 64 characters — documentation classes
-    /// and provenance values.
-    pub(crate) fn token(field: &'static str, value: &str) -> Result<(), ShapeError> {
-        let mut chars = value.chars();
-        if value.len() <= 64
-            && chars.next().is_some_and(|c| c.is_ascii_lowercase())
-            && chars.all(|c| c.is_ascii_alphanumeric())
-        {
-            return Ok(());
-        }
-        fail(
+        Err(ShapeError::Field {
             field,
-            "must be a lowerCamelCase token of at most 64 characters",
-        )
+            rule: "must be a DID",
+        })
     }
 
-    pub(crate) fn tokens(field: &'static str, values: &[String]) -> Result<(), ShapeError> {
-        values.iter().try_for_each(|v| token(field, v))
-    }
-
-    /// `maxItems: 16`, `uniqueItems`, each item at most 35 characters of
-    /// `^[A-Za-z]{2,3}(-[A-Za-z0-9]{1,8})*$`.
-    pub(crate) fn languages(field: &'static str, tags: &[String]) -> Result<(), ShapeError> {
-        if tags.len() > 16 {
-            return fail(field, "lists more than 16 languages");
-        }
-        for (i, tag) in tags.iter().enumerate() {
-            if !language_tag(tag) {
-                return fail(field, "must hold BCP 47 language tags");
-            }
-            if tags[..i].contains(tag) {
-                return fail(field, "repeats a language");
-            }
-        }
-        Ok(())
-    }
-
-    pub(crate) fn language_tag(tag: &str) -> bool {
-        let mut parts = tag.split('-');
-        tag.len() <= 35
-            && parts.next().is_some_and(|primary| {
-                (2..=3).contains(&primary.len()) && primary.bytes().all(|b| b.is_ascii_alphabetic())
-            })
-            && parts.all(|sub| {
-                (1..=8).contains(&sub.len()) && sub.bytes().all(|b| b.is_ascii_alphanumeric())
-            })
-    }
-
-    /// `^[0-9A-HJKMNP-TV-Z]{4}-[0-9A-HJKMNP-TV-Z]{4}$`.
-    pub(crate) fn ticket_code(field: &'static str, code: &str) -> Result<(), ShapeError> {
-        if code.len() == 9
-            && code.bytes().enumerate().all(|(i, b)| {
-                if i == 4 {
-                    b == b'-'
-                } else {
-                    CROCKFORD.contains(&b)
-                }
-            })
-        {
-            return Ok(());
-        }
-        fail(field, "must be XXXX-XXXX in Crockford base32")
-    }
-
-    /// `^[A-Za-z0-9._:-]+$`, at most 128 characters.
-    pub(crate) fn ticket_id(field: &'static str, id: &str) -> Result<(), ShapeError> {
-        if (1..=128).contains(&id.len())
-            && id
-                .bytes()
-                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b':' | b'-'))
-        {
-            return Ok(());
-        }
-        fail(
-            field,
-            "must be 1–128 characters of A–Z, a–z, 0–9, `.`, `_`, `:`, `-`",
-        )
-    }
-
-    /// `^[a-zA-Z][a-zA-Z0-9+.-]*:\S+$`, at most 512 characters — a URI with a
-    /// scheme, such as `urn:uuid:…`. The scheme cannot contain `:`, so the
-    /// first `:` is where it ends.
-    pub(crate) fn statement_id(field: &'static str, id: &str) -> Result<(), ShapeError> {
-        let well_formed = id.split_once(':').is_some_and(|(scheme, rest)| {
-            let mut scheme = scheme.chars();
-            scheme.next().is_some_and(|c| c.is_ascii_alphabetic())
-                && scheme.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '.' | '-'))
-                && !rest.is_empty()
-                && !rest.chars().any(char::is_whitespace)
-        });
-        if well_formed && id.chars().count() <= 512 {
-            return Ok(());
-        }
-        fail(field, "must be a URI of at most 512 characters")
-    }
-
-    /// `^[a-zA-Z][a-zA-Z0-9_-]*$`, at most 128 characters.
-    pub(crate) fn role(field: &'static str, role: &str) -> Result<(), ShapeError> {
-        let mut chars = role.chars();
-        if role.len() <= 128
-            && chars.next().is_some_and(|c| c.is_ascii_alphabetic())
-            && chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
-        {
-            return Ok(());
-        }
-        fail(field, "must be a role name of at most 128 characters")
-    }
-
-    /// `^[A-Z]{2}$` — ISO 3166-1 alpha-2.
-    pub(crate) fn country(field: &'static str, value: &str) -> Result<(), ShapeError> {
-        if value.len() == 2 && value.bytes().all(|b| b.is_ascii_uppercase()) {
-            return Ok(());
-        }
-        fail(field, "must be an uppercase ISO 3166-1 alpha-2 code")
-    }
-
-    /// `^https://\S+$`, at most `max` characters.
-    pub(crate) fn https_url(
-        field: &'static str,
-        value: &str,
-        max: usize,
-    ) -> Result<(), ShapeError> {
-        if value.len() > "https://".len()
-            && value.starts_with("https://")
-            && value.chars().count() <= max
-            && !value.chars().any(|c| c.is_whitespace() || c.is_control())
-        {
-            return Ok(());
-        }
-        fail(field, "must be an https URL of at most 2048 characters")
+    /// `uniqueItems` for a list no embedded schema covers.
+    pub(crate) fn repeats<T: PartialEq>(values: &[T]) -> bool {
+        values
+            .iter()
+            .enumerate()
+            .any(|(i, v)| values[..i].contains(v))
     }
 
     /// Portraits are not carried (D17).
@@ -1845,7 +901,10 @@ pub(crate) mod shape {
         mut claim_types: impl Iterator<Item = &'a str>,
     ) -> Result<(), ShapeError> {
         if claim_types.any(|t| t == PORTRAIT_CLAIM_TYPE) {
-            return fail(field, "must not name person.portrait");
+            return Err(ShapeError::Field {
+                field,
+                rule: "must not name person.portrait",
+            });
         }
         Ok(())
     }
@@ -1854,10 +913,17 @@ pub(crate) mod shape {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::de::DeserializeOwned;
     use serde_json::json;
 
-    fn profile() -> VetterProfileBody {
-        serde_json::from_value(json!({
+    /// Refused as a receiver reads it: by the schema, by the parse, or by
+    /// [`CheckShape`].
+    fn refused<T: trust_tasks_rs::Payload + DeserializeOwned + CheckShape>(value: Value) -> bool {
+        read_checked::<T>(&value).is_err()
+    }
+
+    fn profile_json() -> Value {
+        json!({
             "listed": true,
             "displayName": "Carol",
             "languages": ["en", "de-AT"],
@@ -1873,27 +939,25 @@ mod tests {
                 "location": { "country": "CZ", "city": "Prague" },
                 "url": "https://events.example.org/kms"
             }]
-        }))
-        .unwrap()
+        })
     }
 
     #[test]
-    fn a_vetter_profile_is_camel_case_closed_and_writes_its_arrays() {
-        let p = profile();
+    fn a_vetter_profile_round_trips_as_published_and_is_closed() {
+        let p: vetters::profile::v0_1::Payload = serde_json::from_value(profile_json()).unwrap();
         p.check_shape().unwrap();
-        let v = serde_json::to_value(&p).unwrap();
-        assert_eq!(v["events"][0]["startDate"], "2026-10-05");
-        assert_eq!(v["acceptsDocumentation"][1], "none");
+        assert_eq!(serde_json::to_value(&p).unwrap(), profile_json());
 
         let minimal_json = json!({
             "listed": false, "languages": [], "methods": ["video"],
             "acceptsDocumentation": [], "events": []
         });
-        let minimal: VetterProfileBody = serde_json::from_value(minimal_json.clone()).unwrap();
+        let minimal: vetters::profile::v0_1::Payload =
+            serde_json::from_value(minimal_json.clone()).unwrap();
         minimal.check_shape().unwrap();
-        let v = serde_json::to_value(&minimal).unwrap();
         assert_eq!(
-            v, minimal_json,
+            serde_json::to_value(&minimal).unwrap(),
+            minimal_json,
             "the empty arrays are written, optionals are absent"
         );
 
@@ -1901,7 +965,7 @@ mod tests {
             let mut missing = minimal_json.clone();
             missing.as_object_mut().unwrap().remove(required);
             assert!(
-                serde_json::from_value::<VetterProfileBody>(missing).is_err(),
+                serde_json::from_value::<vetters::profile::v0_1::Payload>(missing).is_err(),
                 "{required} is required"
             );
         }
@@ -1911,15 +975,10 @@ mod tests {
         ] {
             let mut extra = minimal_json.clone();
             extra[member] = value;
-            assert!(serde_json::from_value::<VetterProfileBody>(extra).is_err());
+            assert!(serde_json::from_value::<vetters::profile::v0_1::Payload>(extra).is_err());
         }
-        let response: VetterProfileResponseBody = serde_json::from_value(json!({
-            "listed": true, "updatedAt": "2026-09-15T08:30:01Z"
-        }))
-        .unwrap();
-        assert!(response.listed);
         assert!(
-            serde_json::from_value::<VetterProfileResponseBody>(json!({
+            serde_json::from_value::<vetters::profile::v0_1::Response>(json!({
                 "listed": true, "updatedAt": "2026-09-15T08:30:01Z", "ext": {}
             }))
             .is_err(),
@@ -1928,69 +987,52 @@ mod tests {
     }
 
     #[test]
-    fn a_vetter_profile_is_bounded() {
-        let broken = |f: &dyn Fn(&mut VetterProfileBody)| {
-            let mut p = profile();
+    fn a_vetter_profile_is_bounded_by_its_schema_and_its_event_rule() {
+        type Profile = vetters::profile::v0_1::Payload;
+        let broken = |f: &dyn Fn(&mut Value)| {
+            let mut p = profile_json();
             f(&mut p);
-            p.check_shape().is_err()
+            refused::<Profile>(p)
         };
-        assert!(broken(&|p| p.display_name = Some(String::new())));
-        assert!(broken(&|p| p.display_name = Some("x".repeat(129))));
-        assert!(!broken(&|p| p.display_name = Some("é".repeat(128))));
-        assert!(broken(&|p| p.languages = vec!["x".into()]));
-        assert!(broken(&|p| p.languages = vec!["en".into(), "en".into()]));
-        assert!(broken(
-            &|p| p.languages = (0..17).map(|i| format!("en-{i}")).collect()
-        ));
-        assert!(broken(&|p| p.methods.clear()));
-        assert!(broken(
-            &|p| p.methods = vec![VettingMethod::Video, VettingMethod::Video]
-        ));
-        assert!(broken(
-            &|p| p.accepts_documentation = vec!["Passport".into()]
-        ));
-        assert!(broken(
-            &|p| p.accepts_documentation = vec!["none".into(), "none".into()]
-        ));
-        assert!(broken(
-            &|p| p.accepts_documentation = (0..17).map(|i| format!("doc{i}")).collect()
-        ));
-        assert!(broken(&|p| p.availability = Some("x".repeat(501))));
-        assert!(broken(&|p| p.contact_hint = Some("x".repeat(301))));
-        assert!(broken(
-            &|p| p.location.as_mut().unwrap().country = "cz".into()
-        ));
-        assert!(broken(
-            &|p| p.location.as_mut().unwrap().country = "CZE".into()
-        ));
-        assert!(broken(
-            &|p| p.location.as_mut().unwrap().region = Some(String::new())
-        ));
-        assert!(broken(&|p| p.events = vec![p.events[0].clone(); 33]));
-        assert!(broken(&|p| p.events[0].name = "x".repeat(201)));
-        assert!(broken(
-            &|p| p.events[0].url = Some("http://events.example.org".into())
-        ));
-        assert!(broken(&|p| p.events[0].url = Some("https://a b".into())));
+        assert!(!broken(&|_| {}));
+        assert!(broken(&|p| p["displayName"] = json!("")));
+        assert!(broken(&|p| p["displayName"] = json!("x".repeat(129))));
+        assert!(!broken(&|p| p["displayName"] = json!("é".repeat(128))));
+        assert!(broken(&|p| p["languages"] = json!(["x"])));
+        assert!(broken(&|p| p["languages"] = json!(["en", "en"])));
         assert!(broken(&|p| {
-            p.events[0].end_date = p.events[0].start_date - chrono::Duration::days(1);
+            p["languages"] = json!((0..17).map(|i| format!("en-{i}")).collect::<Vec<_>>());
         }));
+        assert!(broken(&|p| p["methods"] = json!([])));
+        assert!(broken(&|p| p["methods"] = json!(["video", "video"])));
+        assert!(broken(&|p| p["acceptsDocumentation"] = json!(["Passport"])));
+        assert!(broken(
+            &|p| p["acceptsDocumentation"] = json!(["none", "none"])
+        ));
         assert!(broken(&|p| {
-            p.events[0].end_date = p.events[0].start_date + chrono::Duration::days(32);
+            p["acceptsDocumentation"] =
+                json!((0..17).map(|i| format!("doc{i}")).collect::<Vec<_>>());
         }));
-        assert!(!broken(&|p| {
-            p.events[0].end_date = p.events[0].start_date + chrono::Duration::days(31);
+        assert!(broken(&|p| p["availability"] = json!("x".repeat(501))));
+        assert!(broken(&|p| p["contactHint"] = json!("x".repeat(301))));
+        assert!(broken(&|p| p["location"]["country"] = json!("cz")));
+        assert!(broken(&|p| p["location"]["country"] = json!("CZE")));
+        assert!(broken(&|p| p["location"]["region"] = json!("")));
+        assert!(broken(&|p| {
+            let event = p["events"][0].clone();
+            p["events"] = json!(vec![event; 33]);
         }));
+        assert!(broken(&|p| p["events"][0]["name"] = json!("x".repeat(201))));
+        assert!(broken(
+            &|p| p["events"][0]["url"] = json!("http://events.example.org")
+        ));
+        assert!(broken(&|p| p["events"][0]["endDate"] = json!("2026-10-04")));
+        assert!(broken(&|p| p["events"][0]["endDate"] = json!("2026-11-06")));
+        assert!(!broken(&|p| p["events"][0]["endDate"] = json!("2026-11-05")));
     }
 
     #[test]
     fn event_dates_are_exactly_year_month_day() {
-        let event = |start: &str| {
-            serde_json::from_value::<VetterEvent>(json!({
-                "name": "Summit", "startDate": start, "endDate": "2026-10-08"
-            }))
-        };
-        assert!(event("2026-10-05").is_ok());
         for bad in [
             "2026-1-05",
             "26-10-05",
@@ -2000,55 +1042,74 @@ mod tests {
             "2026-02-30",
             "",
         ] {
-            assert!(event(bad).is_err(), "accepted {bad}");
+            let mut p = profile_json();
+            p["events"][0]["startDate"] = json!(bad);
+            assert!(
+                refused::<vetters::profile::v0_1::Payload>(p),
+                "accepted {bad}"
+            );
         }
     }
 
     #[test]
     fn a_listing_request_is_closed_and_bounded() {
-        let body: VetterListBody = serde_json::from_value(json!({
+        type List = vetters::list::v0_1::Payload;
+        let body = json!({
             "language": "de", "country": "AT", "region": "Wien", "city": "Wien",
             "method": "inPerson", "eventFrom": "2026-10-01", "eventTo": "2026-10-31",
             "eventName": "summit", "limit": 100, "cursor": "abc"
-        }))
-        .unwrap();
-        body.check_shape().unwrap();
-        assert!(body.has_event_filter());
-        assert!(!VetterListBody::default().has_event_filter());
-        VetterListBody::default().check_shape().unwrap();
-        assert!(
-            serde_json::from_value::<VetterListBody>(json!({ "memberDid": "did:key:z" })).is_err()
+        });
+        let parsed: List = serde_json::from_value(body.clone()).unwrap();
+        parsed.check_shape().unwrap();
+        assert!(has_event_filter(&parsed));
+        assert!(!has_event_filter(&List::default()));
+        List::default().check_shape().unwrap();
+        assert_eq!(
+            serde_json::to_value(List::default()).unwrap(),
+            json!({}),
+            "every filter is absent, never null"
         );
+        assert!(refused::<List>(json!({ "memberDid": "did:key:z" })));
 
-        let broken = |f: &dyn Fn(&mut VetterListBody)| {
+        for (member, value) in [
+            ("language", json!("deutsch-")),
+            ("country", json!("at")),
+            ("limit", json!(0)),
+            ("limit", json!(101)),
+            ("cursor", json!("x".repeat(513))),
+            ("eventName", json!("x".repeat(201))),
+        ] {
             let mut b = body.clone();
-            f(&mut b);
-            b.check_shape().is_err()
-        };
-        assert!(broken(&|b| b.language = Some("deutsch-".into())));
-        assert!(broken(&|b| b.country = Some("at".into())));
-        assert!(broken(&|b| b.limit = Some(0)));
-        assert!(broken(&|b| b.limit = Some(101)));
-        assert!(broken(&|b| b.cursor = Some("x".repeat(513))));
-        assert!(broken(&|b| b.event_name = Some("x".repeat(201))));
-        assert!(broken(
-            &|b| b.event_to = Some(NaiveDate::from_ymd_opt(2026, 9, 30).unwrap())
-        ));
-        let v = serde_json::to_value(VetterListBody::default()).unwrap();
-        assert_eq!(v, json!({}), "every filter is absent, never null");
+            b[member] = value;
+            assert!(refused::<List>(b), "{member}");
+        }
+        let mut backwards = body;
+        backwards["eventTo"] = json!("2026-09-30");
+        let backwards: List = serde_json::from_value(backwards).unwrap();
+        assert_eq!(
+            backwards.check_shape(),
+            Err(ShapeError::Field {
+                field: "eventTo",
+                rule: "must not be before eventFrom"
+            })
+        );
     }
 
     #[test]
     fn a_resend_carries_nothing_and_answers_with_the_credential() {
-        serde_json::from_value::<VetterResendBody>(json!({})).unwrap();
+        serde_json::from_value::<vetters::resend::v0_1::Payload>(json!({})).unwrap();
         assert!(
-            serde_json::from_value::<VetterResendBody>(json!({ "memberDid": "did:key:z" }))
-                .is_err()
+            serde_json::from_value::<vetters::resend::v0_1::Payload>(
+                json!({ "memberDid": "did:key:z" })
+            )
+            .is_err()
         );
-        let r = VetterResendResponseBody {
-            credential_id: "urn:uuid:g".into(),
-            valid_until: Utc::now(),
-        };
+        let r: vetters::resend::v0_1::Response = vetters::resend::v0_1::Response::builder()
+            .credential_id("urn:uuid:5b0e1c2a-7d4f-4a51-9c6e-2f1b8d3a9e70")
+            .valid_until(Utc::now())
+            .try_into()
+            .unwrap();
+        r.check_shape().unwrap();
         let v = serde_json::to_value(&r).unwrap();
         assert!(v["credentialId"].is_string() && v["validUntil"].is_string());
         assert!(v.get("ext").is_none());
@@ -2107,67 +1168,51 @@ mod tests {
     }
 
     #[test]
-    fn a_vetter_grant_is_camel_case_and_closed() {
-        let body: VetterGrantBody = serde_json::from_value(json!({
+    fn a_vetter_grant_is_closed_and_bounded_by_its_schema() {
+        type Grant = vetters::grant::v0_1::Payload;
+        let body: Grant = serde_json::from_value(json!({
             "memberDid": "did:key:zCarol",
             "validitySeconds": 86_400
         }))
         .unwrap();
         body.check_shape().unwrap();
         assert!(
-            serde_json::from_value::<VetterGrantBody>(json!({
-                "memberDid": "did:key:zCarol",
-                "role": "admin"
-            }))
-            .is_err(),
+            refused::<Grant>(json!({ "memberDid": "did:key:zCarol", "role": "admin" })),
             "the grant names no role: it only ever names a vetter"
         );
-
-        let response = VetterGrantResponseBody {
-            endorsement_id: "e".into(),
-            credential_id: "urn:uuid:e".into(),
-            valid_from: Utc::now(),
-            valid_until: Utc::now(),
-            ext: None,
-        };
-        let v = serde_json::to_value(&response).unwrap();
-        assert!(v["endorsementId"].is_string() && v["validUntil"].is_string());
+        assert!(refused::<Grant>(json!({ "memberDid": "carol" })));
+        for (validity, ok) in [
+            (MIN_VETTER_GRANT_VALIDITY_SECONDS - 1, false),
+            (MIN_VETTER_GRANT_VALIDITY_SECONDS, true),
+            (MAX_VETTER_GRANT_VALIDITY_SECONDS, true),
+            (MAX_VETTER_GRANT_VALIDITY_SECONDS + 1, false),
+        ] {
+            assert_eq!(
+                !refused::<Grant>(
+                    json!({ "memberDid": "did:key:zCarol", "validitySeconds": validity })
+                ),
+                ok,
+                "{validity}"
+            );
+        }
     }
 
+    /// The grant bounds are also enforced on the admin's automatic-grant
+    /// configuration, which no schema covers — so the constants must say what
+    /// the grant schema says.
     #[test]
-    fn a_vetter_grant_is_bounded() {
-        let grant = |did: &str, validity: Option<u64>| VetterGrantBody {
-            member_did: did.into(),
-            validity_seconds: validity,
-            ext: None,
-        };
-        assert!(grant("did:key:zCarol", None).check_shape().is_ok());
-        assert!(grant("carol", None).check_shape().is_err());
-        assert!(
-            grant(
-                "did:key:zCarol",
-                Some(MIN_VETTER_GRANT_VALIDITY_SECONDS - 1)
-            )
-            .check_shape()
-            .is_err()
-        );
-        assert!(
-            grant("did:key:zCarol", Some(MAX_VETTER_GRANT_VALIDITY_SECONDS))
-                .check_shape()
-                .is_ok()
-        );
-        assert!(
-            grant(
-                "did:key:zCarol",
-                Some(MAX_VETTER_GRANT_VALIDITY_SECONDS + 1)
-            )
-            .check_shape()
-            .is_err()
-        );
+    fn the_grant_bounds_are_the_grant_schemas() {
+        let schema: Value = serde_json::from_str(
+            <vetters::grant::v0_1::Payload as trust_tasks_rs::Payload>::PAYLOAD_SCHEMA.unwrap(),
+        )
+        .unwrap();
+        let validity = &schema["properties"]["validitySeconds"];
+        assert_eq!(validity["minimum"], MIN_VETTER_GRANT_VALIDITY_SECONDS);
+        assert_eq!(validity["maximum"], MAX_VETTER_GRANT_VALIDITY_SECONDS);
     }
 
-    fn requirements() -> VettingRequirements {
-        serde_json::from_value(json!({
+    fn requirements_json() -> Value {
+        json!({
             "version": "0.1",
             "statementType": IDENTITY_VETTING_ENDORSEMENT_TYPE,
             "minStatements": 2,
@@ -2177,52 +1222,78 @@ mod tests {
             "maxStatementAge": "P120D",
             "eligibleVetters": { "role": "vetter" },
             "independence": { "maxByDeclaredRelationship": { "family": 0 } }
-        }))
-        .unwrap()
+        })
     }
 
     #[test]
-    fn requirements_round_trip_with_camel_case_members_and_values() {
-        let req = requirements();
+    fn requirements_round_trip_as_published() {
+        let req: VettingRequirements = serde_json::from_value(requirements_json()).unwrap();
         assert_eq!(req.min_by_method.get(&VettingMethod::InPerson), Some(&1));
         assert_eq!(
             req.independence
+                .as_ref()
+                .unwrap()
                 .max_by_declared_relationship
-                .get(&DeclaredRelationship::Family),
+                .get(&VettingRelationship::Family),
             Some(&0)
         );
         let back = serde_json::to_value(&req).unwrap();
-        assert_eq!(back["minByMethod"]["inPerson"], 1);
-        assert_eq!(back["acceptedMethods"][2], "priorAcquaintance");
+        assert_eq!(back, requirements_json());
         // Documentation is the vetter's choice unless a community sets a floor.
         assert!(back.get("acceptedDocumentClasses").is_none());
-        req.validate().unwrap();
+        req.check_shape().unwrap();
+        assert_eq!(max_statement_age(&req), Duration::try_days(120));
     }
 
     #[test]
     fn requirements_tolerate_members_a_newer_community_adds() {
-        let mut v = serde_json::to_value(requirements()).unwrap();
+        let mut v = requirements_json();
         v["vetterDirectory"] = json!(true);
         let req: VettingRequirements = serde_json::from_value(v).unwrap();
-        req.validate().unwrap();
+        req.check_shape().unwrap();
     }
 
     #[test]
-    fn validate_refuses_what_cannot_be_evaluated() {
-        let mut req = requirements();
-        req.min_statements = 0;
-        assert!(req.validate().is_err());
-
-        let mut req = requirements();
-        req.accepted_methods = vec![VettingMethod::Video];
+    fn requirements_that_cannot_be_evaluated_are_refused() {
+        let with = |member: &str, value: Value| {
+            let mut v = requirements_json();
+            v[member] = value;
+            read_requirements(&v).is_err()
+        };
+        assert!(with("minStatements", json!(0)));
+        assert!(with("acceptedMethods", json!([])));
+        assert!(with("acceptedMethods", json!(["video", "video"])));
         assert!(
-            req.validate().unwrap_err().0.contains("inPerson"),
-            "a floor on a method that never counts is unsatisfiable"
+            with("maxStatementAge", json!("P4M")),
+            "months are calendar-dependent"
+        );
+        assert!(with("version", json!("1")), "version is MAJOR.MINOR");
+        assert!(with("eligibleVetters", json!({ "role": "vet ter" })));
+        assert!(with("acceptedDocumentClasses", json!(["national-id"])));
+        assert!(!with(
+            "acceptedDocumentClasses",
+            json!([documentation::NATIONAL_ID])
+        ));
+        assert!(
+            with("governanceFrameworkUrl", json!("http://gov.example")),
+            "governance text is served over https"
+        );
+        assert!(
+            with("decisionSla", json!(format!("PT{}S", "1".repeat(30)))),
+            "durations are at most 32 characters"
         );
 
-        let mut req = requirements();
-        req.max_statement_age = Some("P4M".into());
-        assert!(req.validate().is_err(), "months are calendar-dependent");
+        let mut floor_unaccepted = requirements_json();
+        floor_unaccepted["acceptedMethods"] = json!(["video"]);
+        let req: VettingRequirements = serde_json::from_value(floor_unaccepted).unwrap();
+        assert_eq!(
+            req.check_shape(),
+            Err(ShapeError::Field {
+                field: "minByMethod",
+                rule: "names a method acceptedMethods does not accept"
+            }),
+            "a floor on a method that never counts is unsatisfiable"
+        );
     }
 
     #[test]
@@ -2238,135 +1309,122 @@ mod tests {
         }
     }
 
-    #[test]
-    fn request_shape_rules() {
-        let mut body: VettingRequestBody = serde_json::from_value(json!({
+    fn request_json() -> Value {
+        json!({
             "community": "did:web:vtc.example",
             "joinDid": "did:key:zApplicant",
-            "ticket": { "code": "K7QF-2M9X" }
-        }))
-        .unwrap();
-        assert!(matches!(body.ticket, Some(TicketPresentation::Code { .. })));
-        body.check_shape("did:key:zApplicant").unwrap();
-        assert_eq!(
-            body.check_shape("did:key:zSomeoneElse"),
-            Err(ShapeError::JoinDidNotIssuer)
-        );
-        body.introduction = Some(json!({}));
-        assert_eq!(
-            body.check_shape("did:key:zApplicant"),
-            Err(ShapeError::TicketAndIntroduction)
-        );
+            "ticket": { "code": "K7QF-2M9X" },
+            "languages": ["en", "pt-BR", "zh-Hant-TW"],
+            "message": "Hello"
+        })
     }
 
-    fn field_of(result: Result<(), ShapeError>) -> &'static str {
-        match result {
-            Err(ShapeError::Field { field, .. }) => field,
-            other => panic!("expected a field error, got {other:?}"),
-        }
+    fn request_refused(value: Value) -> bool {
+        read_request(&value, "did:key:zApplicant").is_err()
+    }
+
+    #[test]
+    fn a_request_is_checked_against_its_schema_and_its_issuer() {
+        let body: request::v0_1::Payload = serde_json::from_value(request_json()).unwrap();
+        assert!(matches!(
+            body.ticket,
+            Some(request::v0_1::Ticket::ShortCodeTicket(_))
+        ));
+        check_request(&body, "did:key:zApplicant").unwrap();
+        assert_eq!(
+            check_request(&body, "did:key:zSomeoneElse"),
+            Err(ShapeError::JoinDidNotIssuer)
+        );
+
+        let mut both = request_json();
+        both["introduction"] = json!({ "type": ["VerifiableCredential"] });
+        assert!(
+            matches!(
+                read_request(&both, "did:key:zApplicant"),
+                Err(ShapeError::Schema(_))
+            ),
+            "a ticket or an introduction, not both"
+        );
+        // An empty introduction is still an introduction on the wire, even
+        // though the parsed payload cannot tell it from none.
+        let mut empty_introduction = request_json();
+        empty_introduction["introduction"] = json!({});
+        assert!(read_request(&empty_introduction, "did:key:zApplicant").is_err());
     }
 
     #[test]
     fn request_bounds_follow_the_schema() {
-        let base = || -> VettingRequestBody {
-            serde_json::from_value(json!({
-                "community": "did:web:vtc.example",
-                "joinDid": "did:key:zApplicant",
-                "ticket": { "code": "K7QF-2M9X" },
-                "languages": ["en", "pt-BR", "zh-Hant-TW"],
-                "message": "Hello"
-            }))
-            .unwrap()
-        };
-        let issuer = "did:key:zApplicant";
-        base().check_shape(issuer).unwrap();
-
-        // I, L, O and U are not Crockford characters.
-        let mut b = base();
-        b.ticket = Some(TicketPresentation::Code {
-            code: "K7QF-2M9O".into(),
-        });
-        assert_eq!(field_of(b.check_shape(issuer)), "ticket.code");
-
-        let mut b = base();
-        b.ticket = Some(TicketPresentation::Scanned {
-            ticket_id: "t-1".into(),
-            secret: "too-short".into(),
-        });
-        assert_eq!(field_of(b.check_shape(issuer)), "ticket.secret");
-
-        let mut b = base();
-        b.ticket = Some(TicketPresentation::Scanned {
-            ticket_id: "t 1".into(),
-            secret: "A".repeat(43),
-        });
-        assert_eq!(field_of(b.check_shape(issuer)), "ticket.ticketId");
-
-        let mut b = base();
-        b.languages = vec!["en".into(), "en".into()];
-        assert_eq!(field_of(b.check_shape(issuer)), "languages");
-        b.languages = vec!["english".into()];
-        assert_eq!(field_of(b.check_shape(issuer)), "languages");
-        b.languages = (0..17).map(|i| format!("en-x{i}")).collect();
-        assert_eq!(field_of(b.check_shape(issuer)), "languages");
-
-        let mut b = base();
-        b.message = Some("x".repeat(1001));
-        assert_eq!(field_of(b.check_shape(issuer)), "message");
-        b.message = Some(String::new());
-        assert_eq!(field_of(b.check_shape(issuer)), "message");
-
-        let mut b = base();
-        b.availability = Some("x".repeat(257));
-        assert_eq!(field_of(b.check_shape(issuer)), "availability");
-
-        let mut b = base();
-        b.community = "vtc.example".into();
-        assert_eq!(field_of(b.check_shape(issuer)), "community");
+        assert!(!request_refused(request_json()));
+        for (member, value) in [
+            // I, L, O and U are not Crockford characters.
+            ("ticket", json!({ "code": "K7QF-2M9O" })),
+            (
+                "ticket",
+                json!({ "ticketId": "t-1", "secret": "too-short" }),
+            ),
+            (
+                "ticket",
+                json!({ "ticketId": "t 1", "secret": "A".repeat(43) }),
+            ),
+            (
+                "ticket",
+                json!({ "code": "K7QF-2M9X", "secret": "A".repeat(43) }),
+            ),
+            ("languages", json!(["en", "en"])),
+            ("languages", json!(["english"])),
+            (
+                "languages",
+                json!((0..17).map(|i| format!("en-x{i}")).collect::<Vec<_>>()),
+            ),
+            ("message", json!("x".repeat(1001))),
+            ("message", json!("")),
+            ("availability", json!("x".repeat(257))),
+            ("community", json!("vtc.example")),
+            ("tikcet", json!({ "code": "K7QF-2M9X" })),
+        ] {
+            let mut b = request_json();
+            b[member] = value.clone();
+            assert!(request_refused(b), "{member}: {value}");
+        }
+        let scanned: request::v0_1::Ticket =
+            serde_json::from_value(json!({ "ticketId": "t1", "secret": "A".repeat(43) })).unwrap();
+        assert!(matches!(scanned, request::v0_1::Ticket::QrTicket(_)));
     }
 
     #[test]
     fn reply_and_notice_bounds_follow_the_schema() {
-        let accepted = VettingRequestAcceptedBody {
-            request_id: "r1".into(),
-            eligibility_vp: None,
-            accepts_documentation: vec!["passport".into(), "nationalId".into()],
-            session_hint: Some("Hallway, 3pm".into()),
-            ext: None,
-        };
-        accepted.check_shape().unwrap();
+        let accepted = json!({
+            "requestId": "r1",
+            "acceptsDocumentation": ["passport", "nationalId"],
+            "sessionHint": "Hallway, 3pm"
+        });
+        assert!(!refused::<request::v0_1::Response>(accepted.clone()));
         let mut a = accepted.clone();
-        a.accepts_documentation = vec!["national-id".into()];
-        assert_eq!(field_of(a.check_shape()), "acceptsDocumentation");
+        a["acceptsDocumentation"] = json!(["national-id"]);
+        assert!(refused::<request::v0_1::Response>(a));
         let mut a = accepted;
-        a.request_id = "r".repeat(129);
-        assert_eq!(field_of(a.check_shape()), "requestId");
+        a["requestId"] = json!("r".repeat(129));
+        assert!(refused::<request::v0_1::Response>(a));
 
-        let session = VettingSessionBody {
-            request_id: "r1".into(),
-            challenge: "A".repeat(43),
-            domain: "did:web:vtc.example".into(),
-            method: VettingMethod::Video,
-            required_claims: vec!["name.legal".into()],
-            optional_claims: vec![],
-            expires_at: Utc::now(),
-            ext: None,
-        };
-        session.check_shape().unwrap();
+        let session = json!({
+            "requestId": "r1",
+            "challenge": "A".repeat(43),
+            "domain": "did:web:vtc.example",
+            "method": "video",
+            "requiredClaims": ["name.legal"],
+            "expiresAt": "2026-09-17T15:17:00Z"
+        });
+        assert!(!refused::<session::v0_1::Payload>(session.clone()));
         let mut s = session.clone();
-        s.optional_claims = vec![PORTRAIT_CLAIM_TYPE.into()];
-        assert_eq!(field_of(s.check_shape()), "optionalClaims");
+        s["optionalClaims"] = json!([PORTRAIT_CLAIM_TYPE]);
+        assert!(refused::<session::v0_1::Payload>(s));
         let mut s = session;
-        s.challenge = "A".repeat(44);
-        assert_eq!(field_of(s.check_shape()), "challenge");
+        s["challenge"] = json!("A".repeat(44));
+        assert!(refused::<session::v0_1::Payload>(s));
 
-        let decline = VettingDeclineBody {
-            request_id: "r1".into(),
-            code: Some(DeclineCode::NotComfortable),
-            message: Some("x".repeat(501)),
-            ext: None,
-        };
-        assert_eq!(field_of(decline.check_shape()), "message");
+        assert!(refused::<decline::v0_1::Payload>(json!({
+            "requestId": "r1", "code": "notComfortable", "message": "x".repeat(501)
+        })));
 
         for (id, ok) in [
             ("urn:uuid:5b0e1c2a-7d4f-4a51-9c6e-2f1b8d3a9e70", true),
@@ -2376,62 +1434,92 @@ mod tests {
             ("1urn:x", false),
             ("urn:", false),
         ] {
-            let notice = RevokeStatementBody {
-                statement_id: id.into(),
-                statement_digest_multibase: "zDigest".into(),
-                reason: None,
-                ext: None,
-            };
-            assert_eq!(notice.check_shape().is_ok(), ok, "{id}");
+            let notice = json!({
+                "statementId": id,
+                "statementDigestMultibase": "zQmYimQAvAKzznkjph8xTTpuLhf21jAiUPMy7qdBp7qsU7Z"
+            });
+            assert_eq!(
+                !refused::<revoke_statement::v0_1::Payload>(notice),
+                ok,
+                "{id}"
+            );
         }
     }
 
     #[test]
-    fn requirements_bounds_follow_the_schema() {
-        let mut req = requirements();
-        req.version = "1".into();
-        assert!(req.validate().is_err(), "version is MAJOR.MINOR");
-
-        let mut req = requirements();
-        req.eligible_vetters.role = "vet ter".into();
-        assert!(req.validate().is_err());
-
-        let mut req = requirements();
-        req.accepted_document_classes = Some(vec!["national-id".into()]);
-        assert!(req.validate().is_err(), "documentation is lowerCamelCase");
-        req.accepted_document_classes = Some(vec![documentation::NATIONAL_ID.into()]);
-        req.validate().unwrap();
-
-        let mut req = requirements();
-        req.governance_framework_url = Some("http://gov.example".into());
+    fn branding_is_bounded_by_the_manifest_schema() {
+        assert!(read_branding(&json!({})).is_ok());
         assert!(
-            req.validate().is_err(),
-            "governance text is served over https"
+            read_branding(&json!({
+                "displayName": "Linux Kernel", "accentColor": "#1A2b3c",
+                "logoUrl": "https://kernel.example.org/logo.svg"
+            }))
+            .is_ok()
         );
-
-        let mut req = requirements();
-        req.decision_sla = Some(format!("PT{}S", "1".repeat(30)));
-        assert!(
-            req.validate().is_err(),
-            "durations are at most 32 characters"
-        );
+        for bad in [
+            json!({ "accentColor": "red" }),
+            json!({ "accentColor": "#12345g" }),
+            json!({ "logoUrl": "http://kernel.example.org/logo.svg" }),
+            json!({ "displayName": "x".repeat(129) }),
+            json!({ "displayName": "" }),
+            json!({ "tagline": "x" }),
+        ] {
+            assert!(read_branding(&bad).is_err(), "{bad}");
+        }
     }
 
-    #[test]
-    fn scanned_tickets_parse_as_scanned_not_code() {
-        let t: TicketPresentation =
-            serde_json::from_value(json!({ "ticketId": "t1", "secret": "abc" })).unwrap();
-        assert!(matches!(t, TicketPresentation::Scanned { .. }));
-    }
-
-    #[test]
-    fn request_body_refuses_unknown_members() {
-        let err = serde_json::from_value::<VettingRequestBody>(json!({
+    fn endorsement() -> IdentityVettingEndorsement {
+        serde_json::from_value(json!({
+            "type": IDENTITY_VETTING_ENDORSEMENT_TYPE,
             "community": "did:web:vtc.example",
-            "joinDid": "did:key:zApplicant",
-            "tikcet": { "code": "K7QF-2M9X" }
+            "method": "video",
+            "documentClasses": ["passport"],
+            "claimsVerified": ["name.legal"],
+            "livenessConfirmed": true,
+            "identityCommitment": "zCommitment",
+            "cardDigestMultibase": "zCard",
+            "declaredRelationship": "none"
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn an_endorsement_follows_its_shared_definition() {
+        endorsement().check_shape().unwrap();
+        let broken = |f: &dyn Fn(&mut IdentityVettingEndorsement)| {
+            let mut e = endorsement();
+            f(&mut e);
+            e.check_shape().is_err()
+        };
+        assert!(broken(&|e| e.community = "vtc.example".into()));
+        assert!(broken(&|e| e.endorsement_type = String::new()));
+        assert!(broken(&|e| {
+            e.document_classes
+                .push(documentation::PASSPORT.try_into().unwrap());
         }));
-        assert!(err.is_err(), "a typo must be refused, not ignored");
+        assert!(broken(&|e| {
+            e.document_classes = vec![documentation::NONE.try_into().unwrap()];
+        }));
+        assert!(broken(&|e| {
+            e.claims_verified
+                .push(PORTRAIT_CLAIM_TYPE.try_into().unwrap());
+        }));
+        assert!(!broken(&|e| e.document_classes.clear()));
+        assert!(
+            serde_json::from_value::<IdentityVettingEndorsement>(json!({
+                "type": IDENTITY_VETTING_ENDORSEMENT_TYPE,
+                "community": "did:web:vtc.example",
+                "method": "video",
+                "documentClasses": ["national-id"],
+                "claimsVerified": ["name.legal"],
+                "livenessConfirmed": true,
+                "identityCommitment": "zC",
+                "cardDigestMultibase": "zD",
+                "declaredRelationship": "none"
+            }))
+            .is_err(),
+            "documentation is a lowerCamelCase token"
+        );
     }
 
     #[test]
@@ -2441,8 +1529,8 @@ mod tests {
             VettingMethod::Video,
             VettingMethod::PriorAcquaintance,
         ] {
-            assert_eq!(VettingMethod::parse(m.as_str()), Some(m));
-            assert_eq!(serde_json::to_value(m).unwrap(), json!(m.as_str()));
+            assert_eq!(m.to_string().parse::<VettingMethod>().unwrap(), m);
+            assert_eq!(serde_json::to_value(m).unwrap(), json!(m.to_string()));
         }
     }
 }

--- a/vta-sdk/src/vetting/card.rs
+++ b/vta-sdk/src/vetting/card.rs
@@ -5,6 +5,9 @@
 //! the join DID's key — the same key the final join presentation is signed
 //! with, which is what ties every card, every statement and the join together.
 //!
+//! The card's shape is the published one: [`VettingCard`], generated from
+//! `vetting/session/0.1`, whose `#response` carries it.
+//!
 //! A card is **bound**: to one vetter (`audience`), one session (`challenge`,
 //! `domain`) and a validity window of at most [`MAX_CARD_VALIDITY`]. It cannot
 //! be replayed to another vetter or into another session.
@@ -20,6 +23,8 @@
 //! identity without learning it — and the salt keeps a low-entropy name from
 //! being recovered by enumeration (dtgwg-cred-spec #38).
 
+use std::num::NonZeroU64;
+
 use affinidi_data_integrity::{SignOptions, crypto_suites::CryptoSuite};
 use affinidi_secrets_resolver::secrets::Secret;
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
@@ -27,7 +32,10 @@ use chrono::{DateTime, Duration, Utc};
 use serde_json::{Value, json};
 
 use super::{VettingError, did_of, digest, verify_attached_proof};
-use crate::protocols::vetting::{CardClaim, VETTING_CARD_TYPES, VettingCard};
+use crate::protocols::vetting::session::v0_1::{
+    DataIntegrityProof, Response as SessionResponse, VettingCard, VettingCardClaim,
+};
+use crate::protocols::vetting::{CheckShape, VETTING_CARD_TYPES, against_definition};
 use crate::trust_task_proof::TrustTaskVmResolver;
 
 /// Longest a card may be presentable for.
@@ -40,6 +48,13 @@ pub const CLOCK_SKEW: Duration = Duration::seconds(60);
 pub const CARD_PROOF_PURPOSE: &str = "assertionMethod";
 
 const WHAT: &str = "vetting card";
+
+fn malformed(detail: impl ToString) -> VettingError {
+    VettingError::Malformed {
+        what: WHAT,
+        detail: detail.to_string(),
+    }
+}
 
 /// A fresh per-application commitment salt: 32 random bytes, base64url.
 ///
@@ -61,7 +76,7 @@ pub fn new_commitment_salt() -> Result<String, VettingError> {
 /// [`VettingError::Digest`] if canonicalisation fails.
 pub fn identity_commitment(
     salt: &str,
-    claims: &[CardClaim],
+    claims: &[VettingCardClaim],
     identity_types: &[String],
 ) -> Result<String, VettingError> {
     let mut types: Vec<&String> = identity_types.iter().collect();
@@ -71,9 +86,9 @@ pub fn identity_commitment(
     for claim_type in types {
         let claim = claims
             .iter()
-            .find(|c| &c.claim_type == claim_type)
+            .find(|c| c.type_.as_str() == claim_type.as_str())
             .ok_or_else(|| VettingError::MissingClaim(claim_type.clone()))?;
-        selected.push(json!({ "type": claim.claim_type, "value": claim.value }));
+        selected.push(json!({ "type": claim.type_, "value": claim.value }));
     }
     digest(&json!({ "salt": salt, "claims": selected }))
 }
@@ -81,7 +96,7 @@ pub fn identity_commitment(
 /// Everything needed to make a card.
 #[derive(Debug, Clone)]
 pub struct CardDraft {
-    /// `urn:uuid:…`.
+    /// `urn:uuid:` and a UUID — fresh per card.
     pub id: String,
     /// The applicant's join DID.
     pub publisher: String,
@@ -98,7 +113,7 @@ pub struct CardDraft {
     /// At most [`MAX_CARD_VALIDITY`].
     pub validity: Duration,
     /// The disclosed claims.
-    pub claims: Vec<CardClaim>,
+    pub claims: Vec<VettingCardClaim>,
     /// The claim types the commitment covers — the session's `requiredClaims`.
     pub identity_types: Vec<String>,
     /// The application's salt ([`new_commitment_salt`]).
@@ -111,7 +126,8 @@ pub struct CardDraft {
 ///
 /// [`VettingError::WrongSigner`] if `signer` is not the publisher's key,
 /// [`VettingError::Expired`] if the validity exceeds [`MAX_CARD_VALIDITY`],
-/// [`VettingError::MissingClaim`] if an identity claim is absent, or
+/// [`VettingError::MissingClaim`] if an identity claim is absent,
+/// [`VettingError::Malformed`] if the card breaks its published shape, or
 /// [`VettingError::Sign`].
 pub async fn sign_card(draft: CardDraft, signer: &Secret) -> Result<Value, VettingError> {
     if did_of(&signer.id) != draft.publisher {
@@ -125,27 +141,33 @@ pub async fn sign_card(draft: CardDraft, signer: &Secret) -> Result<Value, Vetti
     }
     let identity_commitment =
         identity_commitment(&draft.salt, &draft.claims, &draft.identity_types)?;
-    let card = VettingCard {
-        types: VETTING_CARD_TYPES.iter().map(ToString::to_string).collect(),
-        id: draft.id,
-        publisher: draft.publisher,
-        card_version: 1,
-        audience: draft.audience,
-        community: draft.community,
-        challenge: draft.challenge,
-        domain: draft.domain,
-        issued_at: draft.issued_at,
-        expires_at: draft.issued_at + draft.validity,
-        claims: draft.claims,
-        identity_commitment,
-        commitment_salt: draft.salt,
-        proof: None,
-    };
-    card.check_shape().map_err(|e| VettingError::Malformed {
-        what: WHAT,
-        detail: e.to_string(),
-    })?;
+
+    // The published card requires its proof. It is built with a well-formed
+    // stand-in, checked, and signed as it serialises without one; the signature
+    // then takes the stand-in's place.
+    let card = VettingCard::try_from(
+        VettingCard::builder()
+            .type_(VETTING_CARD_TYPES.to_vec())
+            .id(draft.id)
+            .publisher(draft.publisher.clone())
+            .card_version(NonZeroU64::MIN)
+            .audience(draft.audience)
+            .community(draft.community)
+            .challenge(draft.challenge)
+            .domain(draft.domain)
+            .issued_at(draft.issued_at)
+            .expires_at(draft.issued_at + draft.validity)
+            .claims(draft.claims)
+            .identity_commitment(identity_commitment)
+            .commitment_salt(draft.salt)
+            .proof(proof_stand_in(&draft.publisher)?),
+    )
+    .map_err(malformed)?;
+    card.check_shape().map_err(malformed)?;
+
     let mut value = serde_json::to_value(&card).map_err(|e| VettingError::Sign(e.to_string()))?;
+    let fields = value.as_object_mut().expect("a card is an object");
+    fields.remove("proof");
     let proof = affinidi_data_integrity::DataIntegrityProof::sign(
         &value,
         signer,
@@ -155,11 +177,33 @@ pub async fn sign_card(draft: CardDraft, signer: &Secret) -> Result<Value, Vetti
     )
     .await
     .map_err(|e| VettingError::Sign(e.to_string()))?;
-    value.as_object_mut().expect("card is an object").insert(
+    value.as_object_mut().expect("a card is an object").insert(
         "proof".into(),
         serde_json::to_value(proof).map_err(|e| VettingError::Sign(e.to_string()))?,
     );
+    parse_card(&value)?;
     Ok(value)
+}
+
+/// A proof member of the published shape, for a card that is not signed yet.
+fn proof_stand_in(publisher: &str) -> Result<DataIntegrityProof, VettingError> {
+    DataIntegrityProof::try_from(
+        DataIntegrityProof::builder()
+            .type_("DataIntegrityProof")
+            .cryptosuite("eddsa-jcs-2022")
+            .verification_method(publisher)
+            .proof_purpose(CARD_PROOF_PURPOSE)
+            .proof_value("z1"),
+    )
+    .map_err(malformed)
+}
+
+/// Read a card as received: the generated type, and the card definition of the
+/// schema `vetting/session/0.1#response` carries it under.
+fn parse_card(value: &Value) -> Result<VettingCard, VettingError> {
+    let card: VettingCard = serde_json::from_value(value.clone()).map_err(malformed)?;
+    against_definition::<SessionResponse>("VettingCard", value).map_err(malformed)?;
+    Ok(card)
 }
 
 /// What a vetter's client expects of the card it receives.
@@ -181,7 +225,7 @@ pub struct CardExpectations<'a> {
     pub now: DateTime<Utc>,
 }
 
-/// A card whose signature, bindings, window and commitment all check.
+/// A card whose shape, signature, bindings, window and commitment all check.
 #[derive(Debug, Clone)]
 pub struct VerifiedVettingCard {
     card: VettingCard,
@@ -204,12 +248,18 @@ impl VerifiedVettingCard {
 
     /// The claim of `claim_type`, if the card carries one.
     #[must_use]
-    pub fn claim(&self, claim_type: &str) -> Option<&CardClaim> {
-        self.card.claims.iter().find(|c| c.claim_type == claim_type)
+    pub fn claim(&self, claim_type: &str) -> Option<&VettingCardClaim> {
+        self.card
+            .claims
+            .iter()
+            .find(|c| c.type_.as_str() == claim_type)
     }
 }
 
 /// Verify a card received in a `vetting/session#response`.
+///
+/// Verification reads `value` — the JSON as received — for the proof and the
+/// digest, never the parsed card re-serialised.
 ///
 /// # Errors
 ///
@@ -222,28 +272,20 @@ pub async fn verify_card(
     expect: &CardExpectations<'_>,
     resolver: &TrustTaskVmResolver,
 ) -> Result<VerifiedVettingCard, VettingError> {
-    let card: VettingCard =
-        serde_json::from_value(value.clone()).map_err(|e| VettingError::Malformed {
-            what: WHAT,
-            detail: e.to_string(),
-        })?;
-    card.check_shape().map_err(|e| VettingError::Malformed {
-        what: WHAT,
-        detail: e.to_string(),
-    })?;
-    if card.audience != expect.audience {
+    let card = parse_card(value)?;
+    if card.audience.as_str() != expect.audience {
         return Err(VettingError::Binding("audience"));
     }
-    if card.publisher != expect.publisher {
+    if card.publisher.as_str() != expect.publisher {
         return Err(VettingError::Binding("publisher"));
     }
-    if card.community != expect.community {
+    if card.community.as_str() != expect.community {
         return Err(VettingError::Binding("community"));
     }
-    if card.challenge != expect.challenge {
+    if card.challenge.as_str() != expect.challenge {
         return Err(VettingError::Binding("challenge"));
     }
-    if card.domain != expect.domain {
+    if card.domain.as_str() != expect.domain {
         return Err(VettingError::Binding("domain"));
     }
     if card.expires_at <= card.issued_at
@@ -255,7 +297,7 @@ pub async fn verify_card(
     }
 
     let signer = verify_attached_proof(WHAT, value, CARD_PROOF_PURPOSE, resolver).await?;
-    if signer != card.publisher {
+    if signer != card.publisher.as_str() {
         return Err(VettingError::WrongSigner {
             what: WHAT,
             role: "publisher",
@@ -263,13 +305,17 @@ pub async fn verify_card(
     }
 
     for required in expect.required_claims {
-        if !card.claims.iter().any(|c| &c.claim_type == required) {
+        if !card
+            .claims
+            .iter()
+            .any(|c| c.type_.as_str() == required.as_str())
+        {
             return Err(VettingError::MissingClaim(required.clone()));
         }
     }
     let recomputed =
         identity_commitment(&card.commitment_salt, &card.claims, expect.required_claims)?;
-    if recomputed != card.identity_commitment {
+    if recomputed != card.identity_commitment.as_str() {
         return Err(VettingError::Commitment);
     }
 
@@ -290,24 +336,26 @@ pub(crate) mod tests {
     pub(crate) const CHALLENGE: &str = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG";
     const SALT: &str = "saltsaltsaltsaltsaltsaltsaltsaltsaltsaltsal";
 
-    pub(crate) fn claims() -> Vec<CardClaim> {
+    pub(crate) fn claim(claim_type: &str, value: Value) -> VettingCardClaim {
+        VettingCardClaim::try_from(
+            VettingCardClaim::builder()
+                .type_(claim_type)
+                .value(value)
+                .provenance("selfAsserted"),
+        )
+        .unwrap()
+    }
+
+    pub(crate) fn claims() -> Vec<VettingCardClaim> {
         vec![
-            CardClaim {
-                claim_type: "name.legal".into(),
-                value: json!("Alice Example"),
-                provenance: "selfAsserted".into(),
-            },
-            CardClaim {
-                claim_type: "account.handle".into(),
-                value: json!("alice@example.org"),
-                provenance: "selfAsserted".into(),
-            },
+            claim("name.legal", json!("Alice Example")),
+            claim("account.handle", json!("alice@example.org")),
         ]
     }
 
     pub(crate) fn draft(applicant: &Secret, vetter: &Secret, now: DateTime<Utc>) -> CardDraft {
         CardDraft {
-            id: "urn:uuid:card-1".into(),
+            id: "urn:uuid:d2c4e6f8-1a3b-4c5d-8e7f-9a0b1c2d3e01".into(),
             publisher: did(applicant),
             audience: did(vetter),
             community: COMMUNITY.into(),
@@ -356,6 +404,11 @@ pub(crate) mod tests {
         .unwrap();
         assert_eq!(verified.claim("name.legal").unwrap().value, "Alice Example");
         assert!(verified.digest_multibase().starts_with('z'));
+        assert_eq!(
+            verified.card().proof.proof_purpose,
+            CARD_PROOF_PURPOSE,
+            "the stand-in proof is replaced by the signature"
+        );
     }
 
     #[tokio::test]
@@ -436,6 +489,17 @@ pub(crate) mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn a_card_id_is_a_urn_uuid() {
+        let (applicant, vetter) = (secret(1), secret(2));
+        let mut d = draft(&applicant, &vetter, Utc::now());
+        d.id = "urn:uuid:card-1".into();
+        assert!(matches!(
+            sign_card(d, &applicant).await.unwrap_err(),
+            VettingError::Malformed { .. }
+        ));
+    }
+
     #[test]
     fn commitment_is_stable_across_vetters_and_blind_to_optional_claims() {
         let identity = vec!["name.legal".to_string()];
@@ -460,11 +524,10 @@ pub(crate) mod tests {
     async fn a_portrait_is_never_signed_onto_a_card() {
         let (applicant, vetter) = (secret(1), secret(2));
         let mut d = draft(&applicant, &vetter, Utc::now());
-        d.claims.push(CardClaim {
-            claim_type: crate::protocols::vetting::PORTRAIT_CLAIM_TYPE.into(),
-            value: json!("data:image/png;base64,AAAA"),
-            provenance: "selfAsserted".into(),
-        });
+        d.claims.push(claim(
+            crate::protocols::vetting::PORTRAIT_CLAIM_TYPE,
+            json!("data:image/png;base64,AAAA"),
+        ));
         assert!(matches!(
             sign_card(d, &applicant).await.unwrap_err(),
             VettingError::Malformed { .. }

--- a/vta-sdk/src/vetting/mod.rs
+++ b/vta-sdk/src/vetting/mod.rs
@@ -1,8 +1,9 @@
 //! Building, signing and verifying the peer-vetting artifacts (feature
 //! `vetting`).
 //!
-//! The wire shapes live in [`crate::protocols::vetting`]; this module is what
-//! gives them meaning:
+//! The wire shapes are the types generated from the published specifications,
+//! re-exported in [`crate::protocols::vetting`]; this module is the behaviour
+//! that operates on them:
 //!
 //! - [`card`] — the Vetting Card an applicant signs for one vetter, and the
 //!   verification a vetter's client runs before showing it.

--- a/vta-sdk/src/vetting/requirements.rs
+++ b/vta-sdk/src/vetting/requirements.rs
@@ -11,6 +11,10 @@
 //!
 //! Keeping the counting in one place means the checklist and the verdict cannot
 //! drift apart on what "two distinct vetters" means.
+//!
+//! The requirements are the published [`VettingRequirements`] of
+//! `vtc/join-requests/manifest/0.2`, and statements are counted in its
+//! vocabulary.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -18,7 +22,9 @@ use chrono::{DateTime, Utc};
 use serde_json::Value;
 
 use super::{VettingError, digest};
-use crate::protocols::vetting::{DeclaredRelationship, VettingMethod, VettingRequirements};
+use crate::protocols::vetting::{
+    VettingMethod, VettingRelationship, VettingRequirements, max_statement_age,
+};
 
 /// The member a criterion's `requirementsDigest` sits in, excluded from its own
 /// digest.
@@ -27,6 +33,9 @@ pub const REQUIREMENTS_DIGEST_MEMBER: &str = "requirementsDigest";
 /// `digestMultibase` over a manifest criterion without its own
 /// `requirementsDigest`. An applicant records it when it starts gathering; a
 /// changed digest means the requirements changed.
+///
+/// Pass the criterion as received: a parsed criterion re-serialised drops any
+/// member its generated type does not name, and so digests to something else.
 ///
 /// # Errors
 ///
@@ -55,7 +64,7 @@ pub struct StatementFacts {
     /// Documentation the vetter relied on.
     pub document_classes: Vec<String>,
     /// Declared relationship.
-    pub declared_relationship: DeclaredRelationship,
+    pub declared_relationship: VettingRelationship,
     /// Identity commitment.
     pub identity_commitment: String,
     /// `validFrom`.
@@ -126,7 +135,7 @@ impl Need {
     pub fn to_wire(self) -> String {
         match self {
             Self::Statements(n) => format!("vetting:statements:{n}"),
-            Self::Method(method, n) => format!("vetting:method:{}:{n}", method.as_str()),
+            Self::Method(method, n) => format!("vetting:method:{method}:{n}"),
         }
     }
 
@@ -139,7 +148,7 @@ impl Need {
             return n.parse().ok().map(Self::Statements);
         }
         let (method, n) = rest.strip_prefix("method:")?.rsplit_once(':')?;
-        Some(Self::Method(VettingMethod::parse(method)?, n.parse().ok()?))
+        Some(Self::Method(method.parse().ok()?, n.parse().ok()?))
     }
 }
 
@@ -153,13 +162,14 @@ pub struct Evaluation {
     /// Counted statements by method.
     pub by_method: BTreeMap<VettingMethod, u32>,
     /// Counted statements by declared relationship.
-    pub by_relationship: BTreeMap<DeclaredRelationship, u32>,
+    pub by_relationship: BTreeMap<VettingRelationship, u32>,
     /// All presented statements carry one identity commitment (or the
     /// requirements do not ask for consistency).
     pub commitments_consistent: bool,
     /// No relationship cap is exceeded.
     pub independence_ok: bool,
-    /// What is still missing. Empty when the count and method floors are met.
+    /// What is still missing, methods in their declared order. Empty when the
+    /// count and method floors are met.
     pub needs: Vec<Need>,
 }
 
@@ -179,13 +189,17 @@ impl Evaluation {
     }
 }
 
+fn saturating_u32(n: u64) -> u32 {
+    u32::try_from(n).unwrap_or(u32::MAX)
+}
+
 /// Count `statements` against `requirements` at `now`.
 ///
 /// Statements from the same vetter count once; the most recent eligible one is
-/// the one kept. Requirements are assumed valid
-/// ([`VettingRequirements::validate`]); an unparseable `maxStatementAge` is
-/// read as the most restrictive interpretation, so nothing counts as young
-/// enough.
+/// the one kept. Requirements are assumed to pass their
+/// [`CheckShape`](crate::protocols::vetting::CheckShape); a `maxStatementAge`
+/// too large to represent is read as the most restrictive interpretation, so
+/// nothing counts as young enough.
 #[must_use]
 pub fn evaluate(
     requirements: &VettingRequirements,
@@ -193,7 +207,9 @@ pub fn evaluate(
     now: DateTime<Utc>,
 ) -> Evaluation {
     let max_age_declared = requirements.max_statement_age.is_some();
-    let max_age = requirements.max_statement_age();
+    let max_age = max_statement_age(requirements);
+    let required_claims = requirements.required_claims.iter().flatten();
+    let independence = requirements.independence.clone().unwrap_or_default();
 
     let mut ordered: Vec<&StatementFacts> = statements.iter().collect();
     ordered.sort_by_key(|s| std::cmp::Reverse(s.valid_from));
@@ -202,7 +218,7 @@ pub fn evaluate(
     let mut not_counted = Vec::new();
     let mut vetters = BTreeSet::new();
     let mut by_method: BTreeMap<VettingMethod, u32> = BTreeMap::new();
-    let mut by_relationship: BTreeMap<DeclaredRelationship, u32> = BTreeMap::new();
+    let mut by_relationship: BTreeMap<VettingRelationship, u32> = BTreeMap::new();
 
     for s in ordered {
         let mut reasons = Vec::new();
@@ -219,16 +235,23 @@ pub fn evaluate(
             reasons.push(NotCounted::MethodNotAccepted);
         }
         if let Some(floor) = &requirements.accepted_document_classes {
-            let documented = s.document_classes.iter().any(|d| floor.contains(d));
+            let documented = s
+                .document_classes
+                .iter()
+                .any(|d| floor.iter().any(|f| f.as_str() == d.as_str()));
             let exempt =
                 s.method == VettingMethod::PriorAcquaintance && s.document_classes.is_empty();
             if !documented && !exempt {
                 reasons.push(NotCounted::DocumentationNotAccepted);
             }
         }
-        for claim in &requirements.required_claims {
-            if !s.claims_verified.contains(claim) {
-                reasons.push(NotCounted::ClaimNotVerified(claim.clone()));
+        for claim in required_claims.clone() {
+            if !s
+                .claims_verified
+                .iter()
+                .any(|c| c.as_str() == claim.as_str())
+            {
+                reasons.push(NotCounted::ClaimNotVerified(claim.to_string()));
             }
         }
         let too_old = match max_age {
@@ -252,9 +275,9 @@ pub fn evaluate(
         }
     }
 
-    let commitments_consistent = !requirements
-        .independence
+    let commitments_consistent = !independence
         .require_consistent_identity_commitment
+        .unwrap_or(false)
         || statements
             .iter()
             .map(|s| s.identity_commitment.as_str())
@@ -262,21 +285,27 @@ pub fn evaluate(
             .len()
             <= 1;
 
-    let independence_ok = requirements
-        .independence
+    let independence_ok = independence
         .max_by_declared_relationship
         .iter()
-        .all(|(rel, max)| by_relationship.get(rel).copied().unwrap_or(0) <= *max);
+        .all(|(rel, max)| u64::from(by_relationship.get(rel).copied().unwrap_or(0)) <= *max);
 
     let mut needs = Vec::new();
-    let have = u32::try_from(counted.len()).unwrap_or(u32::MAX);
-    if have < requirements.min_statements {
-        needs.push(Need::Statements(requirements.min_statements - have));
+    let have = u64::try_from(counted.len()).unwrap_or(u64::MAX);
+    let wanted = requirements.min_statements.get();
+    if have < wanted {
+        needs.push(Need::Statements(saturating_u32(wanted - have)));
     }
-    for (method, floor) in &requirements.min_by_method {
-        let got = by_method.get(method).copied().unwrap_or(0);
-        if got < *floor {
-            needs.push(Need::Method(*method, floor - got));
+    // The floors arrive as a map; report them in a stable order.
+    let floors: BTreeMap<VettingMethod, u64> = requirements
+        .min_by_method
+        .iter()
+        .map(|(m, n)| (*m, *n))
+        .collect();
+    for (method, floor) in floors {
+        let got = u64::from(by_method.get(&method).copied().unwrap_or(0));
+        if got < floor {
+            needs.push(Need::Method(method, saturating_u32(floor - got)));
         }
     }
 
@@ -323,7 +352,7 @@ mod tests {
             method,
             claims_verified: vec!["name.legal".into()],
             document_classes: vec!["passport".into()],
-            declared_relationship: DeclaredRelationship::None,
+            declared_relationship: VettingRelationship::None,
             identity_commitment: "zSame".into(),
             valid_from: Utc::now() - Duration::days(age_days),
             community_matches: true,
@@ -380,6 +409,35 @@ mod tests {
     }
 
     #[test]
+    fn method_floors_are_reported_in_a_stable_order() {
+        let mut req = requirements();
+        req.accepted_methods = vec![
+            VettingMethod::InPerson,
+            VettingMethod::Video,
+            VettingMethod::PriorAcquaintance,
+        ];
+        req.min_by_method = [
+            (VettingMethod::PriorAcquaintance, 1),
+            (VettingMethod::Video, 1),
+            (VettingMethod::InPerson, 1),
+        ]
+        .into_iter()
+        .collect();
+        for _ in 0..8 {
+            let e = evaluate(&req, &[], Utc::now());
+            assert_eq!(
+                e.needs,
+                vec![
+                    Need::Statements(2),
+                    Need::Method(VettingMethod::InPerson, 1),
+                    Need::Method(VettingMethod::Video, 1),
+                    Need::Method(VettingMethod::PriorAcquaintance, 1),
+                ]
+            );
+        }
+    }
+
+    #[test]
     fn ineligible_revoked_stale_and_foreign_statements_do_not_count() {
         let mut ineligible = fact("s1", "a", VettingMethod::InPerson, 1);
         ineligible.eligible = false;
@@ -416,7 +474,7 @@ mod tests {
     #[test]
     fn relationship_caps_are_independence_not_count() {
         let mut family = fact("s2", "dave", VettingMethod::InPerson, 1);
-        family.declared_relationship = DeclaredRelationship::Family;
+        family.declared_relationship = VettingRelationship::Family;
         let e = evaluate(
             &requirements(),
             &[fact("s1", "carol", VettingMethod::Video, 1), family],
@@ -445,13 +503,13 @@ mod tests {
         let mut known = fact("s1", "carol", VettingMethod::PriorAcquaintance, 1);
         known.document_classes.clear();
         let mut odd = fact("s2", "dave", VettingMethod::InPerson, 1);
-        odd.document_classes = vec!["library-card".into()];
+        odd.document_classes = vec!["libraryCard".into()];
 
         let e = evaluate(&requirements(), &[known.clone(), odd.clone()], Utc::now());
         assert!(e.satisfied(), "each vetter decides (D16): {e:?}");
 
         let mut floored = requirements();
-        floored.accepted_document_classes = Some(vec!["passport".into()]);
+        floored.accepted_document_classes = Some(vec!["passport".try_into().unwrap()]);
         let e = evaluate(&floored, &[known, odd], Utc::now());
         assert_eq!(
             e.counted,
@@ -461,9 +519,9 @@ mod tests {
     }
 
     #[test]
-    fn an_unparseable_age_limit_counts_nothing() {
+    fn an_age_limit_too_large_to_represent_counts_nothing() {
         let mut req = requirements();
-        req.max_statement_age = Some("P1Y".into());
+        req.max_statement_age = Some("P9999999999999999999W".try_into().unwrap());
         let e = evaluate(
             &req,
             &[fact("s1", "carol", VettingMethod::InPerson, 0)],

--- a/vta-sdk/src/vetting/statement.rs
+++ b/vta-sdk/src/vetting/statement.rs
@@ -19,7 +19,9 @@ use serde_json::Value;
 
 use super::card::{CLOCK_SKEW, VerifiedVettingCard};
 use super::{VettingError, did_of, digest, verify_attached_proof};
-use crate::protocols::vetting::{IDENTITY_VETTING_ENDORSEMENT_TYPE, IdentityVettingEndorsement};
+use crate::protocols::vetting::{
+    CheckShape, IDENTITY_VETTING_ENDORSEMENT_TYPE, IdentityVettingEndorsement,
+};
 use crate::trust_task_proof::TrustTaskVmResolver;
 
 const WHAT: &str = "vetting statement";
@@ -203,13 +205,13 @@ impl VerifiedVettingStatement {
     /// [`VettingError::Binding`] naming the member that differs.
     pub fn check_against_card(&self, card: &VerifiedVettingCard) -> Result<(), VettingError> {
         let c = card.card();
-        if self.subject != c.publisher {
+        if self.subject != c.publisher.as_str() {
             return Err(VettingError::Binding("subject"));
         }
-        if self.endorsement.community != c.community {
+        if self.endorsement.community != c.community.as_str() {
             return Err(VettingError::Binding("community"));
         }
-        if self.endorsement.identity_commitment != c.identity_commitment {
+        if self.endorsement.identity_commitment != c.identity_commitment.as_str() {
             return Err(VettingError::Binding("identityCommitment"));
         }
         if self.endorsement.card_digest_multibase != card.digest_multibase() {
@@ -295,7 +297,7 @@ pub async fn verify_statement(
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::protocols::vetting::{DeclaredRelationship, VettingMethod};
+    use crate::protocols::vetting::{VettingMethod, VettingRelationship};
     use crate::vetting::card::{
         CardExpectations, sign_card,
         tests::{CHALLENGE, COMMUNITY, draft},
@@ -310,12 +312,12 @@ pub(crate) mod tests {
             endorsement_type: IDENTITY_VETTING_ENDORSEMENT_TYPE.into(),
             community: COMMUNITY.into(),
             method: VettingMethod::Video,
-            document_classes: vec!["passport".into()],
-            claims_verified: vec!["name.legal".into()],
+            document_classes: vec!["passport".try_into().unwrap()],
+            claims_verified: vec!["name.legal".try_into().unwrap()],
             liveness_confirmed: true,
             identity_commitment: commitment.into(),
             card_digest_multibase: card_digest.into(),
-            declared_relationship: DeclaredRelationship::CommunityColleague,
+            declared_relationship: VettingRelationship::CommunityColleague,
             attestation_text_digest: None,
         }
     }

--- a/vta-sdk/src/vetting/ticket_uri.rs
+++ b/vta-sdk/src/vetting/ticket_uri.rs
@@ -11,13 +11,18 @@
 //! `ticket` and `secret`. dtgwg-trust-tasks-tf documents the form informatively
 //! in `vetting/request/0.1` ("Ticket URI").
 //!
+//! The ticket a URI decodes to is the request's own
+//! [`Ticket`](request::Ticket), so its members are checked by the published
+//! types' constructors.
+//!
 //! [`decode`] is strict: it refuses an unknown or missing `v`, a repeated
 //! member, a ticket that is both scanned and spoken, and any member that breaks
 //! the `vetting/request` schema's pattern for it. Members it does not know are
 //! ignored, so a later version can add one without breaking this reader.
 
 use super::VettingError;
-use crate::protocols::vetting::{TicketPresentation, shape};
+use crate::protocols::vetting::request::v0_1 as request;
+use crate::protocols::vetting::shape;
 
 /// The URI scheme of a ticket URI.
 pub const TICKET_URI_SCHEME: &str = "vetting-ticket";
@@ -29,40 +34,45 @@ const WHAT: &str = "ticket URI";
 
 /// A decoded ticket URI: which community, which vetter, and the ticket the
 /// applicant presents in `vetting/request/0.1`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct TicketUri {
     /// The community the vetter vets for.
     pub community: String,
     /// The vetter's DID — the addressee of the request.
     pub vetter: String,
     /// The ticket: scanned (`ticket` + `secret`) or spoken (`code`).
-    pub presentation: TicketPresentation,
+    pub presentation: request::Ticket,
 }
 
 /// Render a ticket as a URI.
 ///
 /// Every value is percent-encoded outside RFC 3986's unreserved set, so a DID's
 /// `:` travels as `%3A`.
-#[must_use]
-pub fn encode(uri: &TicketUri) -> String {
+///
+/// # Errors
+///
+/// [`VettingError::Malformed`] for a ticket form this version of the URI has
+/// no members for — a form a later `vetting/request` adds.
+pub fn encode(uri: &TicketUri) -> Result<String, VettingError> {
     let mut out = format!(
         "{TICKET_URI_SCHEME}:?v={TICKET_URI_VERSION}&community={}&vetter={}",
         pct_encode(&uri.community),
         pct_encode(&uri.vetter)
     );
     match &uri.presentation {
-        TicketPresentation::Scanned { ticket_id, secret } => {
+        request::Ticket::QrTicket(ticket) => {
             out.push_str("&ticket=");
-            out.push_str(&pct_encode(ticket_id));
+            out.push_str(&pct_encode(&ticket.ticket_id));
             out.push_str("&secret=");
-            out.push_str(&pct_encode(secret));
+            out.push_str(&pct_encode(&ticket.secret));
         }
-        TicketPresentation::Code { code } => {
+        request::Ticket::ShortCodeTicket(ticket) => {
             out.push_str("&code=");
-            out.push_str(&pct_encode(code));
+            out.push_str(&pct_encode(&ticket.code));
         }
+        _ => return Err(malformed("a ticket form the URI has no members for")),
     }
-    out
+    Ok(out)
 }
 
 /// Parse a ticket URI.
@@ -128,19 +138,24 @@ pub fn decode(input: &str) -> Result<TicketUri, VettingError> {
 
     let community = members.community.ok_or_else(|| malformed("no community"))?;
     let vetter = members.vetter.ok_or_else(|| malformed("no vetter"))?;
-    shape::did("community", &community).map_err(shape_error)?;
-    shape::did("vetter", &vetter).map_err(shape_error)?;
+    // The community is the request's `community`; the vetter, its addressee.
+    request::PayloadCommunity::try_from(community.as_str())
+        .map_err(|e| malformed(&format!("community: {e}")))?;
+    shape::did("vetter", &vetter).map_err(|e| malformed(&e.to_string()))?;
 
     let presentation = match (members.ticket, members.secret, members.code) {
-        (Some(ticket_id), Some(secret), None) => {
-            shape::ticket_id("ticket", &ticket_id).map_err(shape_error)?;
-            shape::base64url_32("secret", &secret).map_err(shape_error)?;
-            TicketPresentation::Scanned { ticket_id, secret }
-        }
-        (None, None, Some(code)) => {
-            shape::ticket_code("code", &code).map_err(shape_error)?;
-            TicketPresentation::Code { code }
-        }
+        (Some(ticket_id), Some(secret), None) => request::Ticket::QrTicket(
+            request::QrTicket::try_from(
+                request::QrTicket::builder()
+                    .ticket_id(ticket_id)
+                    .secret(secret),
+            )
+            .map_err(|e| malformed(&e.to_string()))?,
+        ),
+        (None, None, Some(code)) => request::Ticket::ShortCodeTicket(
+            request::ShortCodeTicket::try_from(request::ShortCodeTicket::builder().code(code))
+                .map_err(|e| malformed(&e.to_string()))?,
+        ),
         (None, None, None) => return Err(malformed("no ticket")),
         (Some(_), None, None) | (None, Some(_), None) => {
             return Err(malformed("a scanned ticket needs both ticket and secret"));
@@ -169,13 +184,6 @@ fn malformed(detail: &str) -> VettingError {
     VettingError::Malformed {
         what: WHAT,
         detail: detail.to_string(),
-    }
-}
-
-fn shape_error(e: crate::protocols::vetting::ShapeError) -> VettingError {
-    VettingError::Malformed {
-        what: WHAT,
-        detail: e.to_string(),
     }
 }
 
@@ -255,10 +263,10 @@ mod tests {
         TicketUri {
             community: COMMUNITY.into(),
             vetter: VETTER.into(),
-            presentation: TicketPresentation::Scanned {
-                ticket_id: "t-01:ab.c_d".into(),
-                secret: SECRET.into(),
-            },
+            presentation: serde_json::from_value(
+                serde_json::json!({ "ticketId": "t-01:ab.c_d", "secret": SECRET }),
+            )
+            .unwrap(),
         }
     }
 
@@ -266,53 +274,61 @@ mod tests {
         TicketUri {
             community: COMMUNITY.into(),
             vetter: VETTER.into(),
-            presentation: TicketPresentation::Code {
-                code: "K7QF-2M9X".into(),
-            },
+            presentation: serde_json::from_value(serde_json::json!({ "code": "K7QF-2M9X" }))
+                .unwrap(),
         }
+    }
+
+    /// The two decode the same ticket: same community, vetter and ticket JSON.
+    fn same(a: &TicketUri, b: &TicketUri) -> bool {
+        a.community == b.community
+            && a.vetter == b.vetter
+            && serde_json::to_value(&a.presentation).unwrap()
+                == serde_json::to_value(&b.presentation).unwrap()
     }
 
     #[test]
     fn a_scanned_ticket_round_trips() {
-        let uri = encode(&scanned());
+        let uri = encode(&scanned()).unwrap();
         assert_eq!(
             uri,
             "vetting-ticket:?v=1&community=did%3Awebvh%3AQmCommunity%3Avtc.example.com\
              &vetter=did%3Akey%3Az6MkVetter&ticket=t-01%3Aab.c_d&secret=AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8"
         );
-        assert_eq!(decode(&uri).unwrap(), scanned());
+        assert!(same(&decode(&uri).unwrap(), &scanned()));
     }
 
     #[test]
     fn a_spoken_ticket_round_trips() {
-        let uri = encode(&spoken());
+        let uri = encode(&spoken()).unwrap();
         assert!(uri.ends_with("&code=K7QF-2M9X"), "{uri}");
-        assert_eq!(decode(&uri).unwrap(), spoken());
+        assert!(same(&decode(&uri).unwrap(), &spoken()));
     }
 
     #[test]
     fn member_order_the_scheme_case_and_surrounding_whitespace_do_not_matter() {
         let uri = "  VETTING-TICKET:?code=K7QF-2M9X&vetter=did%3Akey%3Az6MkVetter\
                    &community=did%3Awebvh%3AQmCommunity%3Avtc.example.com&v=1\n";
-        assert_eq!(decode(uri).unwrap(), spoken());
+        assert!(same(&decode(uri).unwrap(), &spoken()));
     }
 
     #[test]
     fn an_unknown_member_is_ignored() {
-        let uri = format!("{}&future=yes", encode(&spoken()));
-        assert_eq!(decode(&uri).unwrap(), spoken());
+        let uri = format!("{}&future=yes", encode(&spoken()).unwrap());
+        assert!(same(&decode(&uri).unwrap(), &spoken()));
     }
 
     #[test]
     fn an_unknown_or_missing_version_is_refused() {
-        let v2 = encode(&spoken()).replace("v=1", "v=2");
+        let good = encode(&spoken()).unwrap();
+        let v2 = good.replace("v=1", "v=2");
         assert!(matches!(
             decode(&v2),
             Err(VettingError::UnsupportedVersion { version, .. }) if version == "2"
         ));
-        let none = encode(&spoken()).replace("v=1&", "");
+        let none = good.replace("v=1&", "");
         assert!(matches!(decode(&none), Err(VettingError::Malformed { .. })));
-        let long = encode(&spoken()).replace("v=1", &format!("v={}", "9".repeat(4096)));
+        let long = good.replace("v=1", &format!("v={}", "9".repeat(4096)));
         match decode(&long) {
             Err(VettingError::UnsupportedVersion { version, .. }) => assert_eq!(version.len(), 16),
             other => panic!("expected an unsupported version, got {other:?}"),
@@ -321,9 +337,11 @@ mod tests {
 
     #[test]
     fn a_ticket_is_scanned_or_spoken_but_not_both_or_half() {
-        let both = format!("{}&code=K7QF-2M9X", encode(&scanned()));
+        let both = format!("{}&code=K7QF-2M9X", encode(&scanned()).unwrap());
         assert!(decode(&both).is_err());
-        let half = encode(&scanned()).replace(&format!("&secret={SECRET}"), "");
+        let half = encode(&scanned())
+            .unwrap()
+            .replace(&format!("&secret={SECRET}"), "");
         assert!(decode(&half).is_err());
         let neither = format!(
             "vetting-ticket:?v=1&community={}&vetter={}",
@@ -335,7 +353,8 @@ mod tests {
 
     #[test]
     fn hostile_and_malformed_input_is_refused_without_panicking() {
-        let good = encode(&spoken());
+        let good = encode(&spoken()).unwrap();
+        let scanned_uri = encode(&scanned()).unwrap();
         for bad in [
             String::new(),
             "vetting-ticket".into(),
@@ -359,8 +378,8 @@ mod tests {
             good.replace("K7QF-2M9X", "K7QF2M9X"),
             format!("{good}#frag"),
             format!("{good}&vetter"),
-            encode(&scanned()).replace(SECRET, "short"),
-            encode(&scanned()).replace("t-01%3Aab.c_d", &"a".repeat(129)),
+            scanned_uri.replace(SECRET, "short"),
+            scanned_uri.replace("t-01%3Aab.c_d", &"a".repeat(129)),
             "vetting-ticket:?".to_string() + &"&".repeat(10_000),
         ] {
             assert!(decode(&bad).is_err(), "accepted {bad:?}");

--- a/vta-sdk/tests/generated_wire_types_census.rs
+++ b/vta-sdk/tests/generated_wire_types_census.rs
@@ -1,0 +1,593 @@
+//! Census: no workspace crate hand-writes a serde payload or response type for
+//! a Trust Task whose wire types `trust-tasks-rs` generates.
+//!
+//! ## Why
+//!
+//! The Trust Task specifications in dtgwg-trust-tasks-tf are normative, and
+//! `trust-tasks-codegen` turns each one into Rust types published under
+//! `trust_tasks_rs::specs`. A hand-written copy of one of those types is a
+//! second definition of the wire that nothing keeps in step with the first.
+//!
+//! The peer-vetting work showed what that costs. Its copies drifted from the
+//! published schemas within one stack of pull requests: a documented shape the
+//! schema refused, and an admin console calling a Trust Task URI no route bound.
+//! Those copies were replaced with the generated types; this census stops the
+//! next one being written.
+//!
+//! ## What it treats as a payload or response type
+//!
+//! A wire type in this workspace names the task it carries in the summary of
+//! its doc comment — "`vetting/request/0.1` payload.", "`acl/list/0.1`
+//! response.", "the shape `vtc/backup/export/0.1` publishes". The census reads
+//! every `Serialize` or `Deserialize` struct and enum in every workspace member's
+//! production source. Where the summary names a Trust Task **and** calls the
+//! type a payload, request, response or body, or says the task publishes it, the
+//! census asks `trust_tasks_rs::schema_index` whether that task has a generated
+//! module. If it does, the type duplicates the generated one.
+//!
+//! So name the task in a wire type's summary. A type that carries a task's
+//! payload without saying so is invisible to this census — and to every reader.
+//!
+//! Parsed with `syn`, not grepped, for the reason `payload_ext_census.rs` gives:
+//! attributes span lines, and a line-oriented scan misreads them in the
+//! direction that lets a violation through.
+//!
+//! ## The baseline
+//!
+//! [`PREDATES_GENERATED`] lists the hand-written types that were written before
+//! their task had a generated module. **It only shrinks.** Migrating one to its
+//! generated type removes it from the source, and the census then fails until
+//! its entry goes too. A new type is never added: use the generated one.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use syn::{Attribute, Item, Meta};
+
+const SPEC_AUTHORITY: &str = "https://trusttasks.org/spec/";
+
+/// Hand-written types for tasks that now have generated modules, written before
+/// those modules existed. `(file, type)`, file relative to the workspace root;
+/// the task each restates follows it.
+///
+/// This is migration debt, recorded so it is visible and cannot grow — not a
+/// list of exceptions. The peer-vetting family was the first to be paid off.
+const PREDATES_GENERATED: &[(&str, &str)] = &[
+    ("vta-sdk/src/client/types.rs", "CreateDidWebvhRequest"), // vta/webvh/dids/create/1.0
+    ("vta-sdk/src/client/types.rs", "UpdateContextRequest"),  // vta/contexts/update/1.0
+    (
+        "vta-sdk/src/protocols/acl_management/change_role.rs",
+        "ChangeRoleBody",
+    ), // acl/change-role/0.1
+    (
+        "vta-sdk/src/protocols/acl_management/create.rs",
+        "CreateAclBody",
+    ), // acl/grant/0.1
+    (
+        "vta-sdk/src/protocols/acl_management/create.rs",
+        "CreateAclResponseBody",
+    ), // acl/grant/0.1
+    (
+        "vta-sdk/src/protocols/acl_management/delete.rs",
+        "DeleteAclBody",
+    ), // acl/revoke/0.1
+    (
+        "vta-sdk/src/protocols/acl_management/delete.rs",
+        "DeleteAclResultBody",
+    ), // acl/revoke/0.1
+    ("vta-sdk/src/protocols/acl_management/get.rs", "GetAclBody"), // acl/show/0.1
+    (
+        "vta-sdk/src/protocols/acl_management/get.rs",
+        "GetAclResultBody",
+    ), // acl/show/0.1
+    (
+        "vta-sdk/src/protocols/acl_management/list.rs",
+        "ListAclBody",
+    ), // acl/list/0.1
+    (
+        "vta-sdk/src/protocols/acl_management/list.rs",
+        "ListAclResultBody",
+    ), // acl/list/0.1
+    (
+        "vta-sdk/src/protocols/acl_management/swap.rs",
+        "SwapKeyBody",
+    ), // acl/swap-key/0.1
+    (
+        "vta-sdk/src/protocols/acl_management/swap.rs",
+        "SwapKeyResultBody",
+    ), // acl/swap-key/0.1
+    (
+        "vta-sdk/src/protocols/acl_management/update.rs",
+        "UpdateAclBody",
+    ), // acl/update/0.1
+    (
+        "vta-sdk/src/protocols/audit_management/list.rs",
+        "ListAuditLogsBody",
+    ), // audit/list/0.1
+    (
+        "vta-sdk/src/protocols/audit_management/list.rs",
+        "ListAuditLogsResultBody",
+    ), // audit/list/0.1
+    (
+        "vta-sdk/src/protocols/audit_management/verify.rs",
+        "VerifyChainBody",
+    ), // audit/verify/0.1
+    (
+        "vta-sdk/src/protocols/did_management/servers.rs",
+        "ReconcileWebvhServerDidsBody",
+    ), // vta/webvh/servers/reconcile/0.1
+    (
+        "vta-sdk/src/protocols/discovery.rs",
+        "SupportedTasksResponse",
+    ), // trust-task-discovery/0.1
+    (
+        "vta-sdk/src/protocols/key_management/create.rs",
+        "CreateKeyResponseBody",
+    ), // keys/create/0.1
+    (
+        "vta-sdk/src/protocols/key_management/get.rs",
+        "GetKeyResponseBody",
+    ), // keys/show/0.1
+    (
+        "vta-sdk/src/protocols/key_management/import.rs",
+        "ImportKeyBody",
+    ), // keys/import/0.1
+    (
+        "vta-sdk/src/protocols/policy_management.rs",
+        "DeletePolicyBody",
+    ), // policy/delete/0.1
+    (
+        "vta-sdk/src/protocols/policy_management.rs",
+        "DeletePolicyResultBody",
+    ), // policy/delete/0.1
+    (
+        "vta-sdk/src/protocols/policy_management.rs",
+        "GetPolicyBody",
+    ), // policy/get/0.1
+    (
+        "vta-sdk/src/protocols/policy_management.rs",
+        "GetPolicyResultBody",
+    ), // policy/get/0.1
+    (
+        "vta-sdk/src/protocols/policy_management.rs",
+        "ListPoliciesBody",
+    ), // policy/list/0.2
+    (
+        "vta-sdk/src/protocols/policy_management.rs",
+        "ListPoliciesResultBody",
+    ), // policy/list/0.2
+    (
+        "vta-sdk/src/protocols/policy_management.rs",
+        "UpsertPolicyBody",
+    ), // policy/upsert/0.2
+    (
+        "vta-sdk/src/protocols/policy_management.rs",
+        "UpsertPolicyResultBody",
+    ), // policy/upsert/0.2
+    (
+        "vta-sdk/src/protocols/vta_management/get_config.rs",
+        "GetConfigBody",
+    ), // config/show/0.1
+    (
+        "vta-sdk/src/protocols/vta_management/get_config.rs",
+        "GetConfigResultBody",
+    ), // config/show/0.1
+    (
+        "vta-sdk/src/protocols/vta_management/update_config.rs",
+        "UpdateConfigBody",
+    ), // config/patch/0.1
+    (
+        "vta-sdk/src/protocols/vta_management/update_config.rs",
+        "UpdateConfigResultBody",
+    ), // config/patch/0.1
+    ("vta-service/src/routes/acl.rs", "SwapAclRequest"),      // acl/swap-key/0.1
+    (
+        "vta-service/src/trust_tasks/vault.rs",
+        "VaultListResponseBody",
+    ), // vault/list/0.1
+    (
+        "vta-service/src/trust_tasks/vault.rs",
+        "VaultListStatusFilter",
+    ), // vault/list/0.1
+    (
+        "vta-service/src/trust_tasks/vault.rs",
+        "VaultProxyLoginBody",
+    ), // vault/proxy-login/0.1
+    (
+        "vta-service/src/trust_tasks/vault.rs",
+        "VaultProxyLoginResponseBody",
+    ), // vault/proxy-login/0.1
+    ("vta-service/src/trust_tasks/vault.rs", "VaultReleaseBody"), // vault/release/0.1
+    (
+        "vta-service/src/trust_tasks/vault.rs",
+        "VaultSignTrustTaskBody",
+    ), // vault/sign-trust-task/0.1
+    (
+        "vta-service/src/trust_tasks/vault.rs",
+        "VaultSignTrustTaskResponseBody",
+    ), // vault/sign-trust-task/0.1
+    ("vta-service/src/trust_tasks/vault.rs", "VaultUpsertBody"), // vault/upsert/0.1
+    ("vtc-service/src/routes/admin/config.rs", "ExportResponse"), // vtc/config/export/0.1#response
+    ("vtc-service/src/routes/admin/config.rs", "ImportRequest"), // vtc/config/import/0.1
+    ("vtc-service/src/routes/admin/config.rs", "ImportResponse"), // vtc/config/import/0.1#response
+    (
+        "vtc-service/src/routes/admin/passkeys.rs",
+        "RegisteredCredential",
+    ), // auth/passkey/list/0.1
+    ("vtc-service/src/routes/backup.rs", "ExportResponse"),   // vtc/backup/export/0.1
+    (
+        "vtc-service/src/routes/ceremonies.rs",
+        "CeremonyListResponse",
+    ), // vtc/ceremonies/list/0.1
+    (
+        "vtc-service/src/routes/endorsement_types.rs",
+        "RegisterResponse",
+    ), // vtc/endorsement-types/register/0.1
+    (
+        "vtc-service/src/routes/endorsements.rs",
+        "EndorsementEnvelope",
+    ), // vtc/endorsements/show/0.1
+    ("vtc-service/src/routes/join_requests/decide.rs", "Decision"), // vtc/join-requests/decide/0.1
+    (
+        "vtc-service/src/routes/join_requests/read.rs",
+        "JoinRequestEnvelope",
+    ), // vtc/join-requests/show/0.1
+    ("vtc-service/src/routes/members/read.rs", "MemberEnvelope"), // vtc/members/show/0.1
+    (
+        "vtc-service/src/routes/members/read.rs",
+        "RemovedMembersResponse",
+    ), // vtc/members/removed/0.1
+    ("vtc-service/src/routes/website/files.rs", "DeleteResponse"), // vtc/website/files/delete/0.1
+    (
+        "vtc-service/src/routes/website/generations.rs",
+        "GenerationsResponse",
+    ), // vtc/website/generations/list/0.1
+    (
+        "vtc-service/src/routes/website/generations.rs",
+        "RollbackResponse",
+    ), // vtc/website/rollback/0.1
+    ("vti-rooms/src/wire.rs", "ChainBody"),                   // rooms/epoch/chain/0.1
+    ("vti-rooms/src/wire.rs", "ClaimOwnerBody"),              // rooms/owner/claim/0.1
+    ("vti-rooms/src/wire.rs", "CommitsBody"),                 // rooms/epoch/commits/0.1
+    ("vti-rooms/src/wire.rs", "CreateRoomBody"),              // rooms/create/0.1
+    ("vti-rooms/src/wire.rs", "CurateRecordBody"),            // rooms/records/curate/0.1
+    ("vti-rooms/src/wire.rs", "GetRecordBody"),               // rooms/records/get/0.1
+    ("vti-rooms/src/wire.rs", "ListRecordsBody"),             // rooms/records/list/0.1
+    ("vti-rooms/src/wire.rs", "MintEpochBody"),               // rooms/epoch/mint/0.1
+    ("vti-rooms/src/wire.rs", "PruneBody"),                   // rooms/epoch/prune/0.1
+    ("vti-rooms/src/wire.rs", "PutRecordBody"),               // rooms/records/put/0.1
+    ("vti-rooms/src/wire.rs", "TransferOwnerBody"),           // rooms/owner/transfer/0.1
+];
+
+/// The size of [`PREDATES_GENERATED`], asserted so the list cannot grow quietly.
+const PREDATES_GENERATED_COUNT: usize = 69;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("vta-sdk sits inside the workspace")
+        .to_path_buf()
+}
+
+/// The `[workspace] members` of the root manifest.
+fn workspace_members(root: &Path) -> Vec<String> {
+    let manifest = fs::read_to_string(root.join("Cargo.toml")).expect("workspace manifest");
+    let start = manifest
+        .find("members = [")
+        .expect("the workspace manifest lists its members");
+    let rest = &manifest[start + "members = [".len()..];
+    let list = &rest[..rest.find(']').expect("the members list closes")];
+    list.lines()
+        .map(|line| line.split('#').next().unwrap_or_default())
+        .flat_map(|line| line.split(','))
+        .map(|m| m.trim().trim_matches('"').to_string())
+        .filter(|m| !m.is_empty())
+        .collect()
+}
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("source directory is readable") {
+        let path = entry.expect("readable dir entry").path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+fn attr_tokens(attr: &Attribute, name: &str) -> Option<String> {
+    if !attr.path().is_ident(name) {
+        return None;
+    }
+    match &attr.meta {
+        Meta::List(list) => Some(list.tokens.to_string()),
+        _ => None,
+    }
+}
+
+fn derives_serde(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr_tokens(attr, "derive")
+            .is_some_and(|t| t.contains("Serialize") || t.contains("Deserialize"))
+    })
+}
+
+/// `#[cfg(test)]` items are not wire types.
+fn is_cfg_test(attrs: &[Attribute]) -> bool {
+    attrs
+        .iter()
+        .any(|attr| attr_tokens(attr, "cfg").is_some_and(|t| t.contains("test")))
+}
+
+/// The summary paragraph of a doc comment: its lines up to the first blank.
+fn summary(attrs: &[Attribute]) -> String {
+    let mut lines = Vec::new();
+    for attr in attrs {
+        if !attr.path().is_ident("doc") {
+            continue;
+        }
+        let Meta::NameValue(nv) = &attr.meta else {
+            continue;
+        };
+        let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(text),
+            ..
+        }) = &nv.value
+        else {
+            continue;
+        };
+        let line = text.value();
+        if line.trim().is_empty() {
+            if lines.is_empty() {
+                continue;
+            }
+            break;
+        }
+        lines.push(line.trim().to_string());
+    }
+    lines.join(" ")
+}
+
+/// `slug/path/M.m`, optionally `#response`: the shape of a Trust Task reference
+/// relative to the spec authority.
+fn as_task_reference(candidate: &str) -> Option<String> {
+    let candidate = candidate.strip_prefix(SPEC_AUTHORITY).unwrap_or(candidate);
+    let (path, fragment) = match candidate.split_once('#') {
+        Some((path, "response")) => (path, "#response"),
+        Some(_) => return None,
+        None => (candidate, ""),
+    };
+    let (slug, version) = path.rsplit_once('/')?;
+    let (major, minor) = version.split_once('.')?;
+    let digits = |s: &str| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit());
+    let slug_ok = !slug.is_empty()
+        && slug.split('/').all(|segment| {
+            !segment.is_empty()
+                && segment
+                    .bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        });
+    (slug_ok && digits(major) && digits(minor)).then(|| format!("{path}{fragment}"))
+}
+
+/// The Trust Task references in `text`, and `text` with them — and every other
+/// backticked span — removed, so a member name in backticks is not read as prose.
+fn task_references(text: &str) -> (Vec<String>, String) {
+    let mut references = Vec::new();
+    let mut prose = String::new();
+    for (i, part) in text.split('`').enumerate() {
+        if i % 2 == 1 {
+            references.extend(as_task_reference(part.trim()));
+            continue;
+        }
+        for word in part.split_whitespace() {
+            if word.starts_with(SPEC_AUTHORITY) {
+                let uri = word.trim_end_matches(|c: char| !c.is_ascii_alphanumeric());
+                references.extend(as_task_reference(uri));
+            } else {
+                prose.push_str(word);
+                prose.push(' ');
+            }
+        }
+    }
+    (references, prose)
+}
+
+/// Does the prose call the type a task's payload, request, response or body, or
+/// say a task publishes it?
+fn claims_to_carry(prose: &str) -> bool {
+    prose
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .map(str::to_ascii_lowercase)
+        .any(|w| {
+            matches!(
+                w.as_str(),
+                "payload" | "request" | "response" | "body" | "publishes"
+            )
+        })
+}
+
+/// The generated task a type's summary claims it carries, if any.
+fn claimed_generated_task(attrs: &[Attribute]) -> Option<String> {
+    let (references, prose) = task_references(&summary(attrs));
+    if !claims_to_carry(&prose) {
+        return None;
+    }
+    references.into_iter().find(|r| {
+        trust_tasks_rs::schema_index::schema_for(&format!("{SPEC_AUTHORITY}{r}")).is_some()
+    })
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Found {
+    file: String,
+    ty: String,
+    task: String,
+}
+
+fn walk(items: &[Item], file: &str, inspected: &mut usize, out: &mut Vec<Found>) {
+    for item in items {
+        let (attrs, ident) = match item {
+            Item::Struct(s) => (&s.attrs, &s.ident),
+            Item::Enum(e) => (&e.attrs, &e.ident),
+            Item::Mod(m) if !is_cfg_test(&m.attrs) => {
+                if let Some((_, inner)) = &m.content {
+                    walk(inner, file, inspected, out);
+                }
+                continue;
+            }
+            _ => continue,
+        };
+        if is_cfg_test(attrs) || !derives_serde(attrs) {
+            continue;
+        }
+        *inspected += 1;
+        if let Some(task) = claimed_generated_task(attrs) {
+            out.push(Found {
+                file: file.to_string(),
+                ty: ident.to_string(),
+                task,
+            });
+        }
+    }
+}
+
+fn census() -> (usize, Vec<Found>) {
+    let root = workspace_root();
+    let mut inspected = 0;
+    let mut found = Vec::new();
+    for member in workspace_members(&root) {
+        let src = root.join(&member).join("src");
+        if !src.is_dir() {
+            continue;
+        }
+        let mut files = Vec::new();
+        rust_sources(&src, &mut files);
+        for path in files {
+            let text = fs::read_to_string(&path).expect("source file is readable");
+            let parsed = syn::parse_file(&text)
+                .unwrap_or_else(|e| panic!("{}: does not parse: {e}", path.display()));
+            let rel = path
+                .strip_prefix(&root)
+                .unwrap_or(&path)
+                .components()
+                .map(|c| c.as_os_str().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/");
+            walk(&parsed.items, &rel, &mut inspected, &mut found);
+        }
+    }
+    found.sort();
+    (inspected, found)
+}
+
+#[test]
+fn no_workspace_crate_hand_writes_a_generated_trust_task_type() {
+    let (inspected, found) = census();
+    assert!(
+        inspected > 300,
+        "inspected only {inspected} serde types — the walk is broken, and a census that \
+         inspects nothing passes vacuously"
+    );
+
+    let duplicates: Vec<&Found> = found
+        .iter()
+        .filter(|f| !PREDATES_GENERATED.contains(&(f.file.as_str(), f.ty.as_str())))
+        .collect();
+    assert!(
+        duplicates.is_empty(),
+        "{} hand-written type(s) restate a Trust Task that trust-tasks-rs generates:\n{}\n\n\
+         Use the generated type from `trust_tasks_rs::specs` (the vetting family re-exports \
+         its own from `vta_sdk::protocols::vetting`). A rule the schema cannot state belongs \
+         in a check over the generated type, not in a copy of it. If the specification is \
+         wrong, change it in dtgwg-trust-tasks-tf and take the trust-tasks-rs release that \
+         carries it.",
+        duplicates.len(),
+        duplicates
+            .iter()
+            .map(|f| format!("  (\"{}\", \"{}\"),  // {}", f.file, f.ty, f.task))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    let stale: Vec<&(&str, &str)> = PREDATES_GENERATED
+        .iter()
+        .filter(|(file, ty)| !found.iter().any(|f| f.file == *file && f.ty == *ty))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "PREDATES_GENERATED lists type(s) that no longer restate a generated task — they were \
+         migrated or removed. Delete their entries and lower PREDATES_GENERATED_COUNT:\n{stale:#?}"
+    );
+}
+
+/// The baseline can only shrink: an entry is removed when its type is migrated,
+/// never added.
+#[test]
+fn the_baseline_only_shrinks() {
+    assert_eq!(
+        PREDATES_GENERATED.len(),
+        PREDATES_GENERATED_COUNT,
+        "PREDATES_GENERATED changed size. Removing a migrated type? Lower the count with it. \
+         Adding one? Don't — use the generated type."
+    );
+}
+
+#[test]
+fn the_detector_reads_a_summary_the_way_a_reader_does() {
+    let parse = |src: &str| -> Option<String> {
+        let file = syn::parse_file(src).unwrap();
+        let Item::Struct(s) = &file.items[0] else {
+            panic!("a struct");
+        };
+        claimed_generated_task(&s.attrs)
+    };
+    assert_eq!(
+        parse("/// `vetting/request/0.1` payload.\n#[derive(Serialize)]\nstruct A;"),
+        Some("vetting/request/0.1".into())
+    );
+    assert_eq!(
+        parse(
+            "/// `vtc/vetting/vetters/list/0.1#response` payload.\n#[derive(Serialize)]\nstruct A;"
+        ),
+        Some("vtc/vetting/vetters/list/0.1#response".into())
+    );
+    assert_eq!(
+        parse(
+            "/// The shape https://trusttasks.org/spec/vtc/members/show/0.1 publishes.\n\
+             #[derive(Serialize)]\nstruct A;"
+        ),
+        Some("vtc/members/show/0.1".into())
+    );
+    // Named, but not claimed as the type's own payload.
+    assert_eq!(
+        parse(
+            "/// The ticket an applicant presents in `vetting/request/0.1`.\n\
+             #[derive(Serialize)]\nstruct A;"
+        ),
+        None
+    );
+    // A member called `payload` in backticks is not prose.
+    assert_eq!(
+        parse("/// Holds the `payload` of `vetting/request/0.1`.\n#[derive(Serialize)]\nstruct A;"),
+        None
+    );
+    // Only the summary counts.
+    assert_eq!(
+        parse(
+            "/// A record.\n///\n/// Mentions the `vetting/request/0.1` payload.\n\
+             #[derive(Serialize)]\nstruct A;"
+        ),
+        None
+    );
+    // A task no generated module serves is not this census's business.
+    assert_eq!(
+        parse("/// `example/unpublished/9.9` payload.\n#[derive(Serialize)]\nstruct A;"),
+        None
+    );
+    assert_eq!(
+        as_task_reference("vetting/_shared/0.1/identity-vetting"),
+        None
+    );
+}

--- a/vta-sdk/tests/payload_ext_census.rs
+++ b/vta-sdk/tests/payload_ext_census.rs
@@ -61,45 +61,6 @@ use syn::{Fields, Item, ItemStruct, Meta};
 /// prevent.
 const NO_EXT_BY_DESIGN: &[(&str, &str)] = &[
     (
-        "VetterLocation",
-        "The `location` member of a `vtc/vetting/vetters/profile/0.1` profile and \
-         of each of its events, not a payload root. The vetter-registry contract \
-         closes it to `country`, `region` and `city`; SPEC §4.5.1 gives the `ext` \
-         slot to the profile payload, which carries one.",
-    ),
-    (
-        "VetterEvent",
-        "An entry of a vetter profile's `events`, not a payload root. Closed to \
-         `name`, `startDate`, `endDate`, `location` and `url` by the \
-         vetter-registry contract; the enclosing profile payload carries `ext`.",
-    ),
-    (
-        "ListedVetter",
-        "A row of `vtc/vetting/vetters/list/0.1#response`, not a payload root. \
-         Closed on purpose: a listing discloses the published profile, the DID \
-         and the grant expiry and nothing else, and an open row is where a \
-         second disclosure would creep in. The enclosing response carries `ext`.",
-    ),
-    (
-        "VetterProfileResponseBody",
-        "`vtc/vetting/vetters/profile/0.1#response`. The published schema closes \
-         the response to `listed` and `updatedAt` with no `ext` slot \
-         (dtgwg-trust-tasks-tf#453), so a producer adding one would emit a \
-         document the schema rejects.",
-    ),
-    (
-        "VetterListResponseBody",
-        "`vtc/vetting/vetters/list/0.1#response`. The published schema closes the \
-         response to `vetters` and `nextCursor` with no `ext` slot \
-         (dtgwg-trust-tasks-tf#453).",
-    ),
-    (
-        "VetterResendResponseBody",
-        "`vtc/vetting/vetters/resend/0.1#response`, also the VTC admin resend \
-         answer. The published schema closes it to `credentialId` and \
-         `validUntil` with no `ext` slot (dtgwg-trust-tasks-tf#453).",
-    ),
-    (
         "AutoGrantConfig",
         "The body of the VTC admin REST `PUT /v1/vetting/auto-grant`, not a Trust \
          Task payload. No Trust Task schema names it, so there is no §4.5.1 slot \
@@ -134,21 +95,6 @@ const NO_EXT_BY_DESIGN: &[(&str, &str)] = &[
          with `additionalProperties: false` and no `ext` slot. A member of a \
          payload rather than a payload, exactly as \
          `IssuedCredentialSummary` above.",
-    ),
-    (
-        "VettingCard",
-        "Not a Trust Task payload: the signed Vetting Card (an r-card VDS) that \
-         rides *inside* `vetting/session/0.1#response`'s `card`. SPEC §4.5.1's \
-         slot belongs to that payload, which carries `ext`. The card itself is \
-         closed on purpose — every member of it is signed by the applicant and \
-         shown to a human vetter, and an extension member the vetter's client \
-         cannot render would be a signed claim nobody looked at. The shared card \
-         schema proposed in dtgwg-trust-tasks-tf closes it the same way.",
-    ),
-    (
-        "CardClaim",
-        "One entry of a `VettingCard`'s `claims`, closed for the same reason as \
-         the card: what is signed must be what is shown.",
     ),
     (
         "IdentityVettingEndorsement",

--- a/vtc-client/src/lib.rs
+++ b/vtc-client/src/lib.rs
@@ -260,14 +260,14 @@ pub struct RemoveResult {
 /// returns that grant rather than issuing a second. `created` says which
 /// happened, so an operator is not told "granted" about a grant that already
 /// stood.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct VetterGrant {
     /// `true` when this call issued the grant (HTTP 201), `false` when the
     /// member already held a live one (HTTP 200).
     pub created: bool,
-    /// The grant.
-    pub grant: vetting::VetterGrantResponseBody,
+    /// The grant: the `vtc/vetting/vetters/grant/0.1#response` payload.
+    pub grant: vetting::vetters::grant::v0_1::Response,
 }
 
 /// Outcome of revoking an endorsement (`DELETE /credentials/endorsements/{id}`)
@@ -961,23 +961,18 @@ impl VtcClient {
     /// Name a current member a vetter (`vtc/vetting/vetters/grant/0.1`, over
     /// `POST /vetting/vetters`). Admin token.
     ///
-    /// `validity_seconds` is one day to two years; `None` takes the community's
-    /// default of one year. A member already holding a live grant gets that
-    /// grant back with [`VetterGrant::created`] `false`.
+    /// `grant` is the task's payload: `validitySeconds` is one day to two
+    /// years, and absent takes the community's default of one year. A member
+    /// already holding a live grant gets that grant back with
+    /// [`VetterGrant::created`] `false`.
     pub async fn grant_vetter(
         &self,
-        member_did: &str,
-        validity_seconds: Option<u64>,
+        grant: &vetting::vetters::grant::v0_1::Payload,
     ) -> Result<VetterGrant, VtcError> {
         let url = self.api_url(&["vetting", "vetters"])?;
-        let body = vetting::VetterGrantBody {
-            member_did: member_did.to_string(),
-            validity_seconds,
-            ext: None,
-        };
         let resp = self
             .tt(reqwest::Method::POST, url, task::VETTING_VETTERS_GRANT)?
-            .json(&body)
+            .json(grant)
             .send()
             .await?;
         let resp = expect_success(resp).await?;
@@ -1014,7 +1009,7 @@ impl VtcClient {
     pub async fn resend_vetter_grant(
         &self,
         member_did: &str,
-    ) -> Result<vetting::VetterResendResponseBody, VtcError> {
+    ) -> Result<vetting::vetters::resend::v0_1::Response, VtcError> {
         let url = self.api_url(&["vetting", "vetters", member_did, "resend"])?;
         let resp = self
             .tt(reqwest::Method::POST, url, task::VETTING_VETTERS_RESEND)?
@@ -1048,8 +1043,11 @@ impl VtcClient {
     }
 
     /// How the community presents itself to an applicant's client
-    /// (`GET /community/branding`). Admin token.
-    pub async fn branding(&self) -> Result<join_requests::CommunityBranding, VtcError> {
+    /// (`GET /community/branding`) — the join manifest 0.2 `branding`. Admin
+    /// token.
+    pub async fn branding(
+        &self,
+    ) -> Result<join_requests::manifest::v0_2::CommunityBranding, VtcError> {
         let url = self.api_url(&["community", "branding"])?;
         let resp = self.untasked(reqwest::Method::GET, url)?.send().await?;
         Ok(expect_success(resp).await?.json().await?)
@@ -1060,8 +1058,8 @@ impl VtcClient {
     /// is cleared.
     pub async fn set_branding(
         &self,
-        branding: &join_requests::CommunityBranding,
-    ) -> Result<join_requests::CommunityBranding, VtcError> {
+        branding: &join_requests::manifest::v0_2::CommunityBranding,
+    ) -> Result<join_requests::manifest::v0_2::CommunityBranding, VtcError> {
         let url = self.api_url(&["community", "branding"])?;
         let resp = self
             .untasked(reqwest::Method::PUT, url)?
@@ -1209,7 +1207,12 @@ mod tests {
             Err(VtcError::NotAuthenticated)
         ));
         assert!(matches!(
-            client.grant_vetter("did:key:z", None).await,
+            client
+                .grant_vetter(
+                    &serde_json::from_value(serde_json::json!({ "memberDid": "did:key:z" }))
+                        .unwrap()
+                )
+                .await,
             Err(VtcError::NotAuthenticated)
         ));
         assert!(matches!(

--- a/vtc-service/admin-ui/openapi.json
+++ b/vtc-service/admin-ui/openapi.json
@@ -1445,7 +1445,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CommunityBranding"
+                  "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2CommunityBranding"
                 }
               }
             }
@@ -1470,7 +1470,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CommunityBranding"
+                "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2CommunityBranding"
               }
             }
           },
@@ -1482,7 +1482,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CommunityBranding"
+                  "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2CommunityBranding"
                 }
               }
             }
@@ -2282,7 +2282,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JoinRequestManifestResponseBody"
+                  "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2Response"
                 }
               }
             }
@@ -4578,7 +4578,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/VetterGrantBody"
+                "$ref": "#/components/schemas/VtcVettingVettersGrantV0_1Payload"
               }
             }
           },
@@ -4590,7 +4590,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VetterGrantResponseBody"
+                  "$ref": "#/components/schemas/VtcVettingVettersGrantV0_1Response"
                 }
               }
             }
@@ -4600,7 +4600,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VetterGrantResponseBody"
+                  "$ref": "#/components/schemas/VtcVettingVettersGrantV0_1Response"
                 }
               }
             }
@@ -4634,7 +4634,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/VetterListBody"
+                "$ref": "#/components/schemas/VtcVettingVettersListV0_1Payload"
               }
             }
           },
@@ -4646,7 +4646,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VetterListResponseBody"
+                  "$ref": "#/components/schemas/VtcVettingVettersListV0_1Response"
                 }
               }
             }
@@ -4692,7 +4692,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/VetterResendResponseBody"
+                  "$ref": "#/components/schemas/VtcVettingVettersResendV0_1Response"
                 }
               }
             }
@@ -4753,11 +4753,15 @@
             "description": "The DCQL query, stored as JSON. Structurally validated and every\nreferenced type checked against the registry when stored (see\n[`validate_accepts_query`])."
           },
           "vetting": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "description": "Peer identity vetting this criterion requires, advertised to applicants\nin the join manifest (0.2). Every number in it is this community's\npolicy. Checked by [`VettingRequirements::validate`] when stored; the\nadmin route additionally requires its `statementType` to be a registered\nendorsement type."
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2VettingRequirements",
+                "description": "Peer identity vetting this criterion requires, advertised to applicants\nin the join manifest (0.2): the manifest's own `VettingRequirements`.\nEvery number in it is this community's policy. Checked against the\nmanifest schema when stored; the admin route additionally requires its\n`statementType` to be a registered endorsement type."
+              }
+            ]
           }
         }
       },
@@ -5437,45 +5441,6 @@
             "description": "Echoes the install token's `jti`. Consumer must pass this\nback to `claim/finish` so the server can index the stored\nregistration state."
           }
         }
-      },
-      "CommunityBranding": {
-        "type": "object",
-        "description": "A community's presentation — `join-requests/manifest/0.2`'s `branding`, and\nthe body of the VTC's `GET`/`PUT /v1/community/branding`. Every member is\noptional. Presentation only: a client never trusts a community because of\nhow it is branded.",
-        "properties": {
-          "accentColor": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "`#rrggbb`."
-          },
-          "displayName": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "The name to show; 1–128 characters."
-          },
-          "ext": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/Value",
-                "description": "Ecosystem-defined extension members (SPEC §4.5.1)."
-              }
-            ]
-          },
-          "logoUrl": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "An `https` URL of at most 2048 characters."
-          }
-        },
-        "additionalProperties": false
       },
       "CommunityProfile": {
         "type": "object",
@@ -7066,36 +7031,6 @@
           }
         }
       },
-      "JoinRequestManifestResponseBody": {
-        "type": "object",
-        "description": "Manifest response: the community's join evidence requirements.",
-        "required": [
-          "communityDid",
-          "criteria"
-        ],
-        "properties": {
-          "branding": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/CommunityBranding",
-                "description": "How the community presents itself to an applicant's client (manifest\n0.2). Absent when the community has set none, and always absent from a\n0.1 answer."
-              }
-            ]
-          },
-          "communityDid": {
-            "type": "string"
-          },
-          "criteria": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ManifestCriterion"
-            }
-          }
-        }
-      },
       "JoinRequestVetting": {
         "type": "object",
         "description": "The vetting facts a join request was decided on — the policy's\n`input.evidence.vetting`, in lowerCamelCase.",
@@ -7467,132 +7402,6 @@
               "$ref": "#/components/schemas/RegisteredCredential"
             },
             "description": "`credentials`, the name `auth/passkey/list/0.1` publishes. It was\n`passkeys` until #1112 — the same object under a name the schema does\nnot define, so no conforming client could find it."
-          }
-        }
-      },
-      "ListedVetter": {
-        "type": "object",
-        "description": "One vetter in a listing: the published profile, the DID and the grant's\nexpiry — nothing else about the member.",
-        "required": [
-          "vetterDid",
-          "languages",
-          "methods",
-          "acceptsDocumentation",
-          "events",
-          "grantValidUntil",
-          "updatedAt"
-        ],
-        "properties": {
-          "acceptsDocumentation": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "See [`VetterProfileBody::accepts_documentation`]."
-          },
-          "availability": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "See [`VetterProfileBody::availability`]."
-          },
-          "contactHint": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "See [`VetterProfileBody::contact_hint`]."
-          },
-          "displayName": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "See [`VetterProfileBody::display_name`]."
-          },
-          "events": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/VetterEvent"
-            },
-            "description": "The profile's events that have not ended (`endDate` ≥ today, UTC)."
-          },
-          "grantValidUntil": {
-            "type": "string",
-            "format": "date-time",
-            "description": "When the vetter's grant expires."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "See [`VetterProfileBody::languages`]."
-          },
-          "location": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/VetterLocation",
-                "description": "See [`VetterProfileBody::location`]."
-              }
-            ]
-          },
-          "methods": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/VettingMethod"
-            },
-            "description": "See [`VetterProfileBody::methods`]."
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time",
-            "description": "When the profile was last published."
-          },
-          "vetterDid": {
-            "type": "string",
-            "description": "The vetter's DID — where a `vetting/request` goes."
-          }
-        },
-        "additionalProperties": false
-      },
-      "ManifestCriterion": {
-        "type": "object",
-        "description": "One community evidence requirement — a named DCQL Presentation\nDefinition the applicant may present against.",
-        "required": [
-          "id",
-          "presentationDefinition"
-        ],
-        "properties": {
-          "description": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "id": {
-            "type": "string"
-          },
-          "presentationDefinition": {
-            "$ref": "#/components/schemas/Value"
-          },
-          "requirementsDigest": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "`digestMultibase` over this criterion without this member (manifest\n0.2). An applicant records it when it starts gathering, so a change to\nthe requirements mid-application is detectable."
-          },
-          "vetting": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "description": "Peer identity vetting this criterion requires (manifest 0.2). Absent on\na criterion that needs none."
           }
         }
       },
@@ -8673,11 +8482,15 @@
             "$ref": "#/components/schemas/Value"
           },
           "vetting": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "description": "Peer identity vetting this criterion requires, advertised in the join\nmanifest (0.2). Its `statementType` must be a registered endorsement type."
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2VettingRequirements",
+                "description": "Peer identity vetting this criterion requires, advertised in the join\nmanifest (0.2). Its `statementType` must be a registered endorsement type."
+              }
+            ]
           }
         }
       },
@@ -9955,76 +9768,6 @@
           }
         }
       },
-      "VetterEvent": {
-        "type": "object",
-        "description": "An event a vetter will attend and vet at — a conference, a summit.",
-        "required": [
-          "name",
-          "startDate",
-          "endDate"
-        ],
-        "properties": {
-          "endDate": {
-            "type": "string",
-            "format": "date",
-            "description": "Last day, `YYYY-MM-DD`; not before `startDate`, at most 31 days after it."
-          },
-          "location": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/VetterLocation",
-                "description": "Where it is held."
-              }
-            ]
-          },
-          "name": {
-            "type": "string",
-            "description": "The event's name; 1–200 characters."
-          },
-          "startDate": {
-            "type": "string",
-            "format": "date",
-            "description": "First day, `YYYY-MM-DD`."
-          },
-          "url": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "The event's page; `https`, at most 2048 characters."
-          }
-        },
-        "additionalProperties": false
-      },
-      "VetterGrantBody": {
-        "type": "object",
-        "description": "`vtc/vetting/vetters/grant/0.1` payload.",
-        "required": [
-          "memberDid"
-        ],
-        "properties": {
-          "ext": {
-            "description": "Ecosystem-defined extension members (SPEC §4.5.1)."
-          },
-          "memberDid": {
-            "type": "string",
-            "description": "The member to name as a vetter."
-          },
-          "validitySeconds": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int64",
-            "description": "How long the grant is valid, from one day to two years; one year when\nabsent.",
-            "minimum": 0
-          }
-        },
-        "additionalProperties": false
-      },
       "VetterGrantListResponse": {
         "type": "object",
         "description": "`GET /v1/vetting/vetters` response: every grant, newest first.",
@@ -10040,40 +9783,6 @@
             "description": "The grants."
           }
         }
-      },
-      "VetterGrantResponseBody": {
-        "type": "object",
-        "description": "`vtc/vetting/vetters/grant/0.1#response` payload.\n\nGranting converges: while a grant is live and unexpired, asking again\nreturns it rather than issuing a second.",
-        "required": [
-          "endorsementId",
-          "credentialId",
-          "validFrom",
-          "validUntil"
-        ],
-        "properties": {
-          "credentialId": {
-            "type": "string",
-            "description": "The vetter role credential's `id`."
-          },
-          "endorsementId": {
-            "type": "string",
-            "description": "The community's record of the grant — the id its revocation names."
-          },
-          "ext": {
-            "description": "Ecosystem-defined extension members (SPEC §4.5.1)."
-          },
-          "validFrom": {
-            "type": "string",
-            "format": "date-time",
-            "description": "The credential's `validFrom`."
-          },
-          "validUntil": {
-            "type": "string",
-            "format": "date-time",
-            "description": "The credential's `validUntil`."
-          }
-        },
-        "additionalProperties": false
       },
       "VetterGrantRow": {
         "type": "object",
@@ -10146,146 +9855,6 @@
           }
         }
       },
-      "VetterListBody": {
-        "type": "object",
-        "description": "`vtc/vetting/vetters/list/0.1` payload. Every filter is optional; filters\ncombine with AND.",
-        "properties": {
-          "city": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Case-insensitive exact match on `location.city`."
-          },
-          "country": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "ISO 3166-1 alpha-2, uppercase."
-          },
-          "cursor": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "The `nextCursor` of the previous page; at most 512 characters."
-          },
-          "eventFrom": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "format": "date",
-            "description": "With `eventTo`, a date range a listed event must overlap; an open end is\nunbounded."
-          },
-          "eventName": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Case-insensitive substring of a listed event's name; at most 200\ncharacters."
-          },
-          "eventTo": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "format": "date",
-            "description": "See [`Self::event_from`]."
-          },
-          "ext": {
-            "description": "Ecosystem-defined extension members (SPEC §4.5.1)."
-          },
-          "language": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "A BCP 47 tag. Matches a listed tag equal to it, or one it is a prefix of\nat a subtag boundary (`de` matches `de-AT`). Compared case-insensitively."
-          },
-          "limit": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int32",
-            "description": "Page size, 1–100; 50 when absent.",
-            "minimum": 0
-          },
-          "method": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/VettingMethod",
-                "description": "A method the vetter offers."
-              }
-            ]
-          },
-          "region": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Case-insensitive exact match on `location.region`."
-          }
-        },
-        "additionalProperties": false
-      },
-      "VetterListResponseBody": {
-        "type": "object",
-        "description": "`vtc/vetting/vetters/list/0.1#response` payload.",
-        "required": [
-          "vetters"
-        ],
-        "properties": {
-          "nextCursor": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Pass as `cursor`, with the same filters, for the next page; absent on\nthe last."
-          },
-          "vetters": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ListedVetter"
-            },
-            "description": "This page, in the listing's order."
-          }
-        },
-        "additionalProperties": false
-      },
-      "VetterLocation": {
-        "type": "object",
-        "description": "Where a vetter is, or where an event is held.",
-        "required": [
-          "country"
-        ],
-        "properties": {
-          "city": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "City; 1–128 characters."
-          },
-          "country": {
-            "type": "string",
-            "description": "ISO 3166-1 alpha-2, uppercase."
-          },
-          "region": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Region, state or province; 1–128 characters."
-          }
-        },
-        "additionalProperties": false
-      },
       "VetterProfileSummary": {
         "type": "object",
         "description": "What an admin sees of a vetter's published profile.",
@@ -10329,7 +9898,7 @@
           "methods": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/VettingMethod"
+              "$ref": "#/components/schemas/VtcVettingVettersProfileV0_1VettingMethod"
             },
             "description": "The profile's `methods`."
           },
@@ -10339,35 +9908,6 @@
             "description": "When the profile was last published."
           }
         }
-      },
-      "VetterResendResponseBody": {
-        "type": "object",
-        "description": "`vtc/vetting/vetters/resend/0.1#response` payload — also the answer to the\nadmin `POST /v1/vetting/vetters/{memberDid}/resend`.",
-        "required": [
-          "credentialId",
-          "validUntil"
-        ],
-        "properties": {
-          "credentialId": {
-            "type": "string",
-            "description": "The re-delivered credential's `id`."
-          },
-          "validUntil": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Its `validUntil`."
-          }
-        },
-        "additionalProperties": false
-      },
-      "VettingMethod": {
-        "type": "string",
-        "description": "How a vetter established who the applicant is.",
-        "enum": [
-          "inPerson",
-          "video",
-          "priorAcquaintance"
-        ]
       },
       "VettingRevocationListResponse": {
         "type": "object",
@@ -10443,12 +9983,810 @@
           }
         }
       },
+      "VtcJoinRequestsManifestV0_2ClaimType": {
+        "type": "string",
+        "description": "The vocabulary token naming what a value IS — `name.legal`, `phone.mobile`, `address.postal`, `person.birthDate`. Dotted, most-general segment first, so that a consumer with no knowledge of the specific token can still group by its prefix.\n\nThe token is the maintainer's own; no external vocabulary is primary. External vocabularies (vCard/jCard, OIDC standard claims, schema.org) are mappings applied at PRESENTATION by a renderer, not at rest, so that a query written in any of them can be matched without the store having to live inside any one of them.\n\nThe `x:` prefix is an open extension namespace and is not decoration. The closest prior art — Windows CardSpace's self-issued card — supported exactly fifteen predefined claim types with no extensibility, and that is the specific way it failed the requirement a holder actually has. An `x:` attribute stores, composes, binds and discloses exactly like a known one; it renders generically and matches only an explicit query.",
+        "maxLength": 128,
+        "minLength": 1,
+        "pattern": "^(x:)?[a-z][a-zA-Z0-9]*(\\.[a-z][a-zA-Z0-9]*)*$"
+      },
+      "VtcJoinRequestsManifestV0_2CommunityBranding": {
+        "type": "object",
+        "description": "OPTIONAL. How the community asks to be shown to a prospective applicant: a name, an accent colour and a logo. Presentation only, self-asserted and unverified — `communityDid` identifies the community, never `branding`. Not part of any criterion, so not covered by a `requirementsDigest`. Every member is optional.",
+        "properties": {
+          "accentColor": {
+            "type": "string",
+            "description": "An sRGB colour as `#rrggbb`, compared case-insensitively. A community SHOULD write it in lower case.",
+            "pattern": "^#[0-9a-fA-F]{6}$"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "The community's name as it asks to be shown.",
+            "maxLength": 128,
+            "minLength": 1
+          },
+          "ext": {
+            "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2Ext"
+          },
+          "logoUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "An https URL of the community's logo. Fetched by the client, so an untrusted image from wherever it points.",
+            "maxLength": 2048,
+            "pattern": "^https://"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcJoinRequestsManifestV0_2Criterion": {
+        "type": "object",
+        "required": [
+          "id",
+          "presentationDefinition"
+        ],
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Plain-language summary of the criterion, authored by the community and shown to prospective applicants. Informative: where it and `vetting` disagree, `vetting` governs.",
+            "maxLength": 1024
+          },
+          "id": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1
+          },
+          "presentationDefinition": {
+            "type": "object",
+            "description": "The presentation-definition an applicant must satisfy for this criterion (opaque here)."
+          },
+          "requirementsDigest": {
+            "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2DigestMultibase"
+          },
+          "vetting": {
+            "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2VettingRequirements"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcJoinRequestsManifestV0_2DigestMultibase": {
+        "type": "string",
+        "description": "A cryptographic digest as a multibase-encoded multihash — the encoding the W3C Verifiable Credentials Data Model 2.0 defines for `digestMultibase`, and the one `did:webvh` uses for its SCID and entry hashes.\n\nMultihash carries the hash algorithm in-band, so the value is self-describing and the wire format survives an algorithm change without a schema revision; multibase does the same for the base encoding, so a verifier never infers base58 from base64url by context. A bare hex string or a `sha-256:`-style prefix hard-codes one algorithm into the wire contract and is non-conforming here.\n\nThis definition constrains the *encoding only*. What the digest is computed over is stated by each referencing field, because it differs legitimately: a digest over a JSON document is taken over its RFC 8785 (JCS) canonicalization, while a digest over an opaque artifact is taken over its bytes. A field whose input is a JSON document and which does not name a canonicalization is not reproducible.\n\nRestricted to the two multibase headers W3C Controlled Identifiers 1.0 §2.4 normatively requires — `z` (base58btc) and `u` (base64url-no-pad). CID permits others but states that \"interoperability is not guaranteed between implementations using such values\", and a registry whose purpose is interoperability should not mint digests a conforming verifier may be unable to read. The alphabets are enforced rather than assumed: base58btc excludes 0, O, I and l, and an earlier permissive pattern let three published examples carry digests that were not valid base58 at all. base58btc is RECOMMENDED, for consistency with `did:key` and `did:webvh`.",
+        "minLength": 16,
+        "pattern": "^(z[1-9A-HJ-NP-Za-km-z]+|u[A-Za-z0-9_-]+)$"
+      },
+      "VtcJoinRequestsManifestV0_2Duration": {
+        "type": "string",
+        "description": "An ISO 8601 duration in weeks, days, hours, minutes and seconds only (e.g. `P120D`, `P2W`, `P1DT12H`, `PT15M`). Years and months are refused: their length depends on the calendar, and an age limit that means different things on different days is not a limit.",
+        "maxLength": 32,
+        "pattern": "^P(([0-9]+W)?([0-9]+D)?T([0-9]+H([0-9]+M)?([0-9]+S)?|[0-9]+M([0-9]+S)?|[0-9]+S)|[0-9]+W([0-9]+D)?|[0-9]+D)$"
+      },
+      "VtcJoinRequestsManifestV0_2Ext": {
+        "type": "object",
+        "description": "Vendor-namespaced extension object per SPEC.md §4.5.1. Each immediate key MUST be a reverse-DNS namespace; structure under each namespace is opaque to the framework.",
+        "additionalProperties": true,
+        "minProperties": 1
+      },
+      "VtcJoinRequestsManifestV0_2Response": {
+        "type": "object",
+        "required": [
+          "communityDid",
+          "criteria"
+        ],
+        "properties": {
+          "branding": {
+            "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2CommunityBranding"
+          },
+          "communityDid": {
+            "type": "string",
+            "pattern": "^did:"
+          },
+          "criteria": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2Criterion"
+            }
+          },
+          "ext": {
+            "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2Ext"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcJoinRequestsManifestV0_2VettingDocumentation": {
+        "type": "string",
+        "description": "A class of documentation, named in lowerCamelCase. Open rather than enumerated, because what documentation a vetter accepts is each vetter's own choice. Well-known values: `passport`, `nationalId`, `driverLicence`, and `none` — the vetter will attest without a document, which is the `priorAcquaintance` case. Only the class ever travels — never a document number, an image, an issuing authority or an expiry date. `none` states a policy (what a vetter accepts); a record of what was relied on expresses 'no document' as an empty list instead.",
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[a-z][a-zA-Z0-9]*$"
+      },
+      "VtcJoinRequestsManifestV0_2VettingMethod": {
+        "type": "string",
+        "description": "How the vetter established that the person they checked is the person controlling the applicant's DID. `inPerson` — both people were physically together. `video` — a live, two-way video call. `priorAcquaintance` — the vetter has known or worked with this person over a period, and attests from that knowledge rather than from a document. A method is a description of what happened, not an assurance level: which methods count, and how many of each, is community policy.",
+        "enum": [
+          "inPerson",
+          "video",
+          "priorAcquaintance"
+        ]
+      },
+      "VtcJoinRequestsManifestV0_2VettingRelationship": {
+        "type": "string",
+        "description": "The vetter's own declaration of how they relate to the applicant. Declared, not verified: it exists so community policy can cap how much evidence comes from people close to the applicant, and a false declaration is the vetter's attributable act.",
+        "enum": [
+          "none",
+          "communityColleague",
+          "sameEmployer",
+          "family",
+          "otherPersonal"
+        ]
+      },
+      "VtcJoinRequestsManifestV0_2VettingRequirements": {
+        "type": "object",
+        "description": "What identity-vetting evidence a criterion needs, beyond what a presentation-definition can express: distinct eligible vetters, per-method floors, independence caps. Every number is the community's own policy. This schema supplies no defaults — an absent optional member means the community imposes no constraint of that kind, never that some protocol value applies. Deliberately open: a consumer MUST ignore members it does not recognise, so a community publishing a newer shape does not make an older client unable to read the rest. Durations: `maxStatementAge` — a statement older than this at decision time does not count (absent: no limit beyond the statement's own validity); `decisionSla` — how long after submission the community undertakes to decide, including on a referred application; `requirementsGrace` — how long an application started under an earlier `requirementsDigest` is still evaluated under that version.",
+        "required": [
+          "version",
+          "statementType",
+          "minStatements",
+          "acceptedMethods",
+          "eligibleVetters"
+        ],
+        "properties": {
+          "acceptedDocumentClasses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2VettingDocumentation"
+            },
+            "description": "Documentation a statement must have relied on in order to count. Absent — the expected case — means each vetter decides what documentation they accept, including none for prior acquaintance, and the community counts what they attest.",
+            "minItems": 1,
+            "uniqueItems": true
+          },
+          "acceptedMethods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2VettingMethod"
+            },
+            "description": "Methods whose statements count at all.",
+            "minItems": 1,
+            "uniqueItems": true
+          },
+          "decisionSla": {
+            "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2Duration"
+          },
+          "eligibleVetters": {
+            "type": "object",
+            "description": "How a vetter's eligibility is established.",
+            "required": [
+              "role"
+            ],
+            "properties": {
+              "role": {
+                "type": "string",
+                "description": "The role named in a community-issued `CommunityRole` endorsement credential (see `vtc/vetting/vetters/grant/0.1`). A statement counts only if its issuer holds that credential.",
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z][a-zA-Z0-9_-]*$"
+              }
+            },
+            "additionalProperties": false
+          },
+          "governanceFrameworkUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "Where the community's vetting governance — including the attestation text vetters sign — is published.",
+            "maxLength": 2048,
+            "pattern": "^https://"
+          },
+          "independence": {
+            "type": "object",
+            "description": "Caps on how much evidence may come from people close to the applicant. Absent: no caps.",
+            "properties": {
+              "maxByDeclaredRelationship": {
+                "type": "object",
+                "description": "The most counted statements that may come from vetters declaring each relationship — e.g. `{ \"family\": 0 }`.",
+                "additionalProperties": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "requireConsistentIdentityCommitment": {
+                "type": "boolean",
+                "description": "When true, every counted statement must carry the same identity commitment — all vetters verified the same claimed identity. Absent: false."
+              }
+            },
+            "additionalProperties": false
+          },
+          "invitation": {
+            "type": "string",
+            "description": "Whether an invitation credential must accompany the statements at submission (`required`), may (`optional`), or plays no part (`none`). Absent: the presentation-definition alone governs.",
+            "enum": [
+              "required",
+              "optional",
+              "none"
+            ]
+          },
+          "maxStatementAge": {
+            "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2Duration"
+          },
+          "minByMethod": {
+            "type": "object",
+            "description": "Per-method floors within `minStatements` — e.g. `{ \"inPerson\": 1 }`. Every method named MUST also be in `acceptedMethods`. Absent: no method floor.",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "minStatements": {
+            "type": "integer",
+            "description": "How many counted statements are needed, counting each vetter once however many DIDs they hold.",
+            "minimum": 1
+          },
+          "optionalClaims": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2ClaimType"
+            },
+            "description": "Claim types an applicant MAY add to the card and a vetter MAY verify. They never affect whether a statement counts.",
+            "uniqueItems": true
+          },
+          "requiredClaims": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2ClaimType"
+            },
+            "description": "Claim types the applicant's Vetting Card must carry, which the identity commitment is computed over, and which a counted statement must list as verified. Absent: none.",
+            "uniqueItems": true
+          },
+          "requirementsGrace": {
+            "$ref": "#/components/schemas/VtcJoinRequestsManifestV0_2Duration"
+          },
+          "statementType": {
+            "type": "string",
+            "format": "uri",
+            "description": "The endorsement type URI a counted vetting statement carries as `credentialSubject.endorsement.type`, as registered with the community via vtc/endorsement-types/register.",
+            "maxLength": 512,
+            "minLength": 1
+          },
+          "version": {
+            "type": "string",
+            "description": "Version of this requirements object's shape. `0.1` for the members defined here.",
+            "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          }
+        },
+        "additionalProperties": true
+      },
       "VtcRole": {
         "type": "string",
         "description": "One of `admin`, `moderator`, `issuer`, `member`, or                  `custom:<name>` where `<name>` is 1..=64 lowercase                  alphanumerics, `-`, or `_`.",
         "examples": [
           "admin"
         ]
+      },
+      "VtcVettingVettersGrantV0_1Ext": {
+        "type": "object",
+        "description": "Vendor-namespaced extension object per SPEC.md §4.5.1. Each immediate key MUST be a reverse-DNS namespace; structure under each namespace is opaque to the framework.",
+        "additionalProperties": true,
+        "minProperties": 1
+      },
+      "VtcVettingVettersGrantV0_1Payload": {
+        "type": "object",
+        "description": "A community administrator makes a member a vetter. The community issues the member a revocable `CommunityRole` endorsement credential for the `vetter` role, delivers it over credential-exchange/issue, and returns the identifiers and validity of the grant. A member who already holds a live grant gets that grant back unchanged.",
+        "required": [
+          "memberDid"
+        ],
+        "properties": {
+          "ext": {
+            "$ref": "#/components/schemas/VtcVettingVettersGrantV0_1Ext"
+          },
+          "memberDid": {
+            "type": "string",
+            "description": "The member DID to grant the vetter role to — the subject of the role credential, and the DID the vetter signs statements with.",
+            "pattern": "^did:"
+          },
+          "validitySeconds": {
+            "type": "integer",
+            "description": "OPTIONAL. How long the role credential is valid, from issuance: at least one day, at most two years. Absent: 31536000 (365 days). Ignored when the member already holds a live grant.",
+            "maximum": 63072000,
+            "minimum": 86400
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcVettingVettersGrantV0_1Response": {
+        "type": "object",
+        "description": "The grant — newly issued, or the member's existing live grant.",
+        "required": [
+          "endorsementId",
+          "credentialId",
+          "validFrom",
+          "validUntil"
+        ],
+        "properties": {
+          "credentialId": {
+            "type": "string",
+            "description": "The `id` of the role credential, a URI.",
+            "maxLength": 512,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9+.-]*:\\S+$"
+          },
+          "endorsementId": {
+            "type": "string",
+            "description": "The community's endorsement record for this grant — the identifier vtc/endorsements/revoke takes.",
+            "maxLength": 128,
+            "minLength": 1
+          },
+          "ext": {
+            "$ref": "#/components/schemas/VtcVettingVettersGrantV0_1Ext"
+          },
+          "validFrom": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The role credential's `validFrom`."
+          },
+          "validUntil": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The role credential's `validUntil`."
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcVettingVettersListV0_1CalendarDate": {
+        "type": "string",
+        "format": "date",
+        "description": "A calendar date, `YYYY-MM-DD` (RFC 3339 full-date), with no time or zone. Compared as a UTC date.",
+        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+      },
+      "VtcVettingVettersListV0_1CountryCode": {
+        "type": "string",
+        "description": "An ISO 3166-1 alpha-2 country code, upper case, e.g. `DE`.",
+        "pattern": "^[A-Z]{2}$"
+      },
+      "VtcVettingVettersListV0_1Ext": {
+        "type": "object",
+        "description": "Vendor-namespaced extension object per SPEC.md §4.5.1. Each immediate key MUST be a reverse-DNS namespace; structure under each namespace is opaque to the framework.",
+        "additionalProperties": true,
+        "minProperties": 1
+      },
+      "VtcVettingVettersListV0_1LanguageTag": {
+        "type": "string",
+        "description": "A BCP 47 language tag, e.g. `en`, `de-AT`. Compared case-insensitively.",
+        "maxLength": 35,
+        "minLength": 2,
+        "pattern": "^[A-Za-z]{2,3}(-[A-Za-z0-9]{1,8})*$"
+      },
+      "VtcVettingVettersListV0_1ListedVetter": {
+        "type": "object",
+        "description": "One listed vetter: the published profile without `listed` and `ext`, the vetter's DID, the expiry of their live grant, and when the profile was stored. Nothing else about the member is disclosed.",
+        "required": [
+          "vetterDid",
+          "languages",
+          "methods",
+          "acceptsDocumentation",
+          "events",
+          "grantValidUntil",
+          "updatedAt"
+        ],
+        "properties": {
+          "acceptsDocumentation": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1VetterAcceptsDocumentation"
+          },
+          "availability": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1VetterAvailability"
+          },
+          "contactHint": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1VetterContactHint"
+          },
+          "displayName": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1VetterDisplayName"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VtcVettingVettersListV0_1VetterEvent"
+            },
+            "description": "The profile's events whose `endDate` is today (UTC) or later. Ended events are never returned.",
+            "maxItems": 32
+          },
+          "grantValidUntil": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The `validUntil` of the vetter's live vetter role credential."
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VtcVettingVettersListV0_1LanguageTag"
+            },
+            "maxItems": 16,
+            "uniqueItems": true
+          },
+          "location": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1VetterLocation"
+          },
+          "methods": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1VetterMethods"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the community stored this profile, as returned by vtc/vetting/vetters/profile."
+          },
+          "vetterDid": {
+            "type": "string",
+            "description": "The vetter's member DID — the subject of their vetter role credential, and the DID a vetting/request is addressed to.",
+            "pattern": "^did:"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcVettingVettersListV0_1Payload": {
+        "type": "object",
+        "description": "An authenticated applicant or member asks a community for its listed vetters, optionally filtered by language, location, method or event. Only active members with a live vetter grant and a profile stored with `listed: true` appear, and each entry carries only what the vetter published, their DID and their grant's expiry. Every filter is optional; filters combine with AND.",
+        "properties": {
+          "city": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1PlaceName"
+          },
+          "country": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1CountryCode"
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Opaque continuation token from a previous page's `nextCursor`, sent with the same filters.",
+            "maxLength": 512,
+            "minLength": 1
+          },
+          "eventFrom": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1CalendarDate"
+          },
+          "eventName": {
+            "type": "string",
+            "description": "Matches an event whose `name` contains this text, case-insensitively.",
+            "maxLength": 200,
+            "minLength": 1
+          },
+          "eventTo": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1CalendarDate"
+          },
+          "ext": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1Ext"
+          },
+          "language": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1LanguageTag"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Most entries to return. Absent: 50.",
+            "maximum": 100,
+            "minimum": 1
+          },
+          "method": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1VettingMethod"
+          },
+          "region": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1PlaceName"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcVettingVettersListV0_1PlaceName": {
+        "type": "string",
+        "description": "A region or city name as the vetter writes it. Compared case-insensitively and otherwise exactly.",
+        "maxLength": 128,
+        "minLength": 1
+      },
+      "VtcVettingVettersListV0_1Response": {
+        "type": "object",
+        "description": "One page of listed vetters matching every filter sent.",
+        "required": [
+          "vetters"
+        ],
+        "properties": {
+          "nextCursor": {
+            "type": "string",
+            "description": "Present when more entries match; send it as `cursor`, with the same filters, for the next page. Absent on the last page.",
+            "maxLength": 512,
+            "minLength": 1
+          },
+          "vetters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VtcVettingVettersListV0_1ListedVetter"
+            },
+            "description": "The page, in the order Conformance defines. May be empty.",
+            "maxItems": 100
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcVettingVettersListV0_1VetterAcceptsDocumentation": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/VtcVettingVettersListV0_1VettingDocumentation"
+        },
+        "description": "What documentation the vetter relies on, in the same tokens as vetting/request's `acceptsDocumentation` — `passport`, `nationalId`, `driverLicence`, `none`, or another lowerCamelCase class. The vetter's own choice; empty says nothing either way.",
+        "maxItems": 16,
+        "uniqueItems": true
+      },
+      "VtcVettingVettersListV0_1VetterAvailability": {
+        "type": "string",
+        "description": "Vetter-authored free text on when they are available to vet. Attributed to the vetter.",
+        "maxLength": 500,
+        "minLength": 1
+      },
+      "VtcVettingVettersListV0_1VetterContactHint": {
+        "type": "string",
+        "description": "Vetter-authored free text on how to obtain a ticket from them, e.g. `Find me at the OpenVTC booth`. A hint, not an address a request can be sent to: vetting/request still needs a ticket or an introduction the vetter accepts.",
+        "maxLength": 300,
+        "minLength": 1
+      },
+      "VtcVettingVettersListV0_1VetterDisplayName": {
+        "type": "string",
+        "description": "The name the vetter chooses to be listed under. Self-asserted and unverified: it is not the name on any document, and a client MUST attribute it to the vetter.",
+        "maxLength": 128,
+        "minLength": 1
+      },
+      "VtcVettingVettersListV0_1VetterEvent": {
+        "type": "object",
+        "description": "An event the vetter will attend and vet at. `endDate` is on or after `startDate` and no more than 31 days after it; JSON Schema cannot compare two members, so the community checks both and refuses a violation with `malformedRequest`.",
+        "required": [
+          "name",
+          "startDate",
+          "endDate"
+        ],
+        "properties": {
+          "endDate": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1CalendarDate"
+          },
+          "location": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1VetterLocation"
+          },
+          "name": {
+            "type": "string",
+            "description": "The event's name, e.g. `Linux Plumbers Conference 2026`.",
+            "maxLength": 200,
+            "minLength": 1
+          },
+          "startDate": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1CalendarDate"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "OPTIONAL. The event's own https page.",
+            "maxLength": 2048,
+            "pattern": "^https://"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcVettingVettersListV0_1VetterLocation": {
+        "type": "object",
+        "description": "Where a vetter can meet people, as coarse as the vetter chooses: a country, optionally a region, optionally a city. Never a street address.",
+        "required": [
+          "country"
+        ],
+        "properties": {
+          "city": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1PlaceName"
+          },
+          "country": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1CountryCode"
+          },
+          "region": {
+            "$ref": "#/components/schemas/VtcVettingVettersListV0_1PlaceName"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcVettingVettersListV0_1VetterMethods": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/VtcVettingVettersListV0_1VettingMethod"
+        },
+        "description": "The methods the vetter offers, from `inPerson`, `video`, `priorAcquaintance`.",
+        "maxItems": 3,
+        "minItems": 1,
+        "uniqueItems": true
+      },
+      "VtcVettingVettersListV0_1VettingDocumentation": {
+        "type": "string",
+        "description": "A class of documentation, named in lowerCamelCase. Open rather than enumerated, because what documentation a vetter accepts is each vetter's own choice. Well-known values: `passport`, `nationalId`, `driverLicence`, and `none` — the vetter will attest without a document, which is the `priorAcquaintance` case. Only the class ever travels — never a document number, an image, an issuing authority or an expiry date. `none` states a policy (what a vetter accepts); a record of what was relied on expresses 'no document' as an empty list instead.",
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[a-z][a-zA-Z0-9]*$"
+      },
+      "VtcVettingVettersListV0_1VettingMethod": {
+        "type": "string",
+        "description": "How the vetter established that the person they checked is the person controlling the applicant's DID. `inPerson` — both people were physically together. `video` — a live, two-way video call. `priorAcquaintance` — the vetter has known or worked with this person over a period, and attests from that knowledge rather than from a document. A method is a description of what happened, not an assurance level: which methods count, and how many of each, is community policy.",
+        "enum": [
+          "inPerson",
+          "video",
+          "priorAcquaintance"
+        ]
+      },
+      "VtcVettingVettersProfileV0_1CalendarDate": {
+        "type": "string",
+        "format": "date",
+        "description": "A calendar date, `YYYY-MM-DD` (RFC 3339 full-date), with no time or zone. Compared as a UTC date.",
+        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+      },
+      "VtcVettingVettersProfileV0_1CountryCode": {
+        "type": "string",
+        "description": "An ISO 3166-1 alpha-2 country code, upper case, e.g. `DE`.",
+        "pattern": "^[A-Z]{2}$"
+      },
+      "VtcVettingVettersProfileV0_1Ext": {
+        "type": "object",
+        "description": "Vendor-namespaced extension object per SPEC.md §4.5.1. Each immediate key MUST be a reverse-DNS namespace; structure under each namespace is opaque to the framework.",
+        "additionalProperties": true,
+        "minProperties": 1
+      },
+      "VtcVettingVettersProfileV0_1LanguageTag": {
+        "type": "string",
+        "description": "A BCP 47 language tag, e.g. `en`, `de-AT`. Compared case-insensitively.",
+        "maxLength": 35,
+        "minLength": 2,
+        "pattern": "^[A-Za-z]{2,3}(-[A-Za-z0-9]{1,8})*$"
+      },
+      "VtcVettingVettersProfileV0_1PlaceName": {
+        "type": "string",
+        "description": "A region or city name as the vetter writes it. Compared case-insensitively and otherwise exactly.",
+        "maxLength": 128,
+        "minLength": 1
+      },
+      "VtcVettingVettersProfileV0_1Response": {
+        "type": "object",
+        "description": "The community stored the profile.",
+        "required": [
+          "listed",
+          "updatedAt"
+        ],
+        "properties": {
+          "listed": {
+            "type": "boolean",
+            "description": "The stored profile's `listed` value."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the community stored this profile. vtc/vetting/vetters/list returns the same value."
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcVettingVettersProfileV0_1VetterAcceptsDocumentation": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/VtcVettingVettersProfileV0_1VettingDocumentation"
+        },
+        "description": "What documentation the vetter relies on, in the same tokens as vetting/request's `acceptsDocumentation` — `passport`, `nationalId`, `driverLicence`, `none`, or another lowerCamelCase class. The vetter's own choice; empty says nothing either way.",
+        "maxItems": 16,
+        "uniqueItems": true
+      },
+      "VtcVettingVettersProfileV0_1VetterAvailability": {
+        "type": "string",
+        "description": "Vetter-authored free text on when they are available to vet. Attributed to the vetter.",
+        "maxLength": 500,
+        "minLength": 1
+      },
+      "VtcVettingVettersProfileV0_1VetterContactHint": {
+        "type": "string",
+        "description": "Vetter-authored free text on how to obtain a ticket from them, e.g. `Find me at the OpenVTC booth`. A hint, not an address a request can be sent to: vetting/request still needs a ticket or an introduction the vetter accepts.",
+        "maxLength": 300,
+        "minLength": 1
+      },
+      "VtcVettingVettersProfileV0_1VetterDisplayName": {
+        "type": "string",
+        "description": "The name the vetter chooses to be listed under. Self-asserted and unverified: it is not the name on any document, and a client MUST attribute it to the vetter.",
+        "maxLength": 128,
+        "minLength": 1
+      },
+      "VtcVettingVettersProfileV0_1VetterEvent": {
+        "type": "object",
+        "description": "An event the vetter will attend and vet at. `endDate` is on or after `startDate` and no more than 31 days after it; JSON Schema cannot compare two members, so the community checks both and refuses a violation with `malformedRequest`.",
+        "required": [
+          "name",
+          "startDate",
+          "endDate"
+        ],
+        "properties": {
+          "endDate": {
+            "$ref": "#/components/schemas/VtcVettingVettersProfileV0_1CalendarDate"
+          },
+          "location": {
+            "$ref": "#/components/schemas/VtcVettingVettersProfileV0_1VetterLocation"
+          },
+          "name": {
+            "type": "string",
+            "description": "The event's name, e.g. `Linux Plumbers Conference 2026`.",
+            "maxLength": 200,
+            "minLength": 1
+          },
+          "startDate": {
+            "$ref": "#/components/schemas/VtcVettingVettersProfileV0_1CalendarDate"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "OPTIONAL. The event's own https page.",
+            "maxLength": 2048,
+            "pattern": "^https://"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcVettingVettersProfileV0_1VetterLocation": {
+        "type": "object",
+        "description": "Where a vetter can meet people, as coarse as the vetter chooses: a country, optionally a region, optionally a city. Never a street address.",
+        "required": [
+          "country"
+        ],
+        "properties": {
+          "city": {
+            "$ref": "#/components/schemas/VtcVettingVettersProfileV0_1PlaceName"
+          },
+          "country": {
+            "$ref": "#/components/schemas/VtcVettingVettersProfileV0_1CountryCode"
+          },
+          "region": {
+            "$ref": "#/components/schemas/VtcVettingVettersProfileV0_1PlaceName"
+          }
+        },
+        "additionalProperties": false
+      },
+      "VtcVettingVettersProfileV0_1VetterMethods": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/VtcVettingVettersProfileV0_1VettingMethod"
+        },
+        "description": "The methods the vetter offers, from `inPerson`, `video`, `priorAcquaintance`.",
+        "maxItems": 3,
+        "minItems": 1,
+        "uniqueItems": true
+      },
+      "VtcVettingVettersProfileV0_1VettingDocumentation": {
+        "type": "string",
+        "description": "A class of documentation, named in lowerCamelCase. Open rather than enumerated, because what documentation a vetter accepts is each vetter's own choice. Well-known values: `passport`, `nationalId`, `driverLicence`, and `none` — the vetter will attest without a document, which is the `priorAcquaintance` case. Only the class ever travels — never a document number, an image, an issuing authority or an expiry date. `none` states a policy (what a vetter accepts); a record of what was relied on expresses 'no document' as an empty list instead.",
+        "maxLength": 64,
+        "minLength": 1,
+        "pattern": "^[a-z][a-zA-Z0-9]*$"
+      },
+      "VtcVettingVettersProfileV0_1VettingMethod": {
+        "type": "string",
+        "description": "How the vetter established that the person they checked is the person controlling the applicant's DID. `inPerson` — both people were physically together. `video` — a live, two-way video call. `priorAcquaintance` — the vetter has known or worked with this person over a period, and attests from that knowledge rather than from a document. A method is a description of what happened, not an assurance level: which methods count, and how many of each, is community policy.",
+        "enum": [
+          "inPerson",
+          "video",
+          "priorAcquaintance"
+        ]
+      },
+      "VtcVettingVettersResendV0_1Ext": {
+        "type": "object",
+        "description": "Vendor-namespaced extension object per SPEC.md §4.5.1. Each immediate key MUST be a reverse-DNS namespace; structure under each namespace is opaque to the framework.",
+        "additionalProperties": true,
+        "minProperties": 1
+      },
+      "VtcVettingVettersResendV0_1Response": {
+        "type": "object",
+        "description": "The credential the community delivered again.",
+        "required": [
+          "credentialId",
+          "validUntil"
+        ],
+        "properties": {
+          "credentialId": {
+            "type": "string",
+            "description": "The `id` of the vetter role credential delivered — the same `credentialId` vtc/vetting/vetters/grant returned.",
+            "maxLength": 512,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z][a-zA-Z0-9+.-]*:\\S+$"
+          },
+          "validUntil": {
+            "type": "string",
+            "format": "date-time",
+            "description": "That credential's `validUntil`."
+          }
+        },
+        "additionalProperties": false
       },
       "WhoamiResponse": {
         "type": "object",

--- a/vtc-service/admin-ui/src/lib/vetting.test.ts
+++ b/vtc-service/admin-ui/src/lib/vetting.test.ts
@@ -10,6 +10,7 @@ import {
   factsHeadline,
   filterGrants,
   grantState,
+  httpsUriProblem,
   isLanguageTag,
   parseIsoDuration,
   statementVerdict,
@@ -387,5 +388,59 @@ describe("branding mirrors CommunityBranding::check_shape", () => {
         logoUrl: "https://kernel.example.org/my logo.svg",
       }).logoUrl,
     ).toMatch(/spaces/);
+    expect(
+      validateBranding({
+        displayName: "",
+        accentColor: "",
+        logoUrl: "https://kernel.example.org/logo\u0007.svg",
+      }).logoUrl,
+    ).toMatch(/control characters/);
+    expect(
+      validateBranding({
+        displayName: "",
+        accentColor: "",
+        logoUrl: "https:///logo.svg",
+      }).logoUrl,
+    ).toMatch(/complete address/);
+  });
+});
+
+describe("httpsUriProblem mirrors shape::https_uri", () => {
+  it.each([
+    "https://events.example.org",
+    "https://events.example.org/kms?day=1#hall-b",
+    "https://example.org/caf%C3%A9",
+    "https://[2001:db8::1]:8443/logo.svg",
+  ])("accepts %s", (url) => {
+    expect(httpsUriProblem(url)).toBeNull();
+  });
+
+  it.each([
+    ["https://events.example.org/kernel meetup", "whitespace"],
+    ["https://events.example.org/\u0007", "whitespace"],
+    ["https://events.example.org/\tx", "whitespace"],
+    ["http://events.example.org", "notHttpsUri"],
+    ["events.example.org", "notHttpsUri"],
+    ["https://", "notHttpsUri"],
+    ["https:///path", "notHttpsUri"],
+    ["https://?q=1", "notHttpsUri"],
+    ["https://example.org/%zz", "notHttpsUri"],
+    ["https://example.org/café", "notHttpsUri"],
+    ["https://example.org/<logo>", "notHttpsUri"],
+    [`https://example.org/${"a".repeat(2048)}`, "length"],
+  ])("refuses %j as %s", (url, problem) => {
+    expect(httpsUriProblem(url)).toBe(problem);
+  });
+
+  it("holds the governance framework address to the same rule", () => {
+    for (const governanceFrameworkUrl of [
+      "https://gov.example/frame work",
+      "https://gov.example/\u001b",
+      "http://gov.example/gf",
+    ]) {
+      expect(
+        validateRequirements({ ...REQUIREMENTS, governanceFrameworkUrl }),
+      ).toHaveLength(1);
+    }
   });
 });

--- a/vtc-service/admin-ui/src/lib/vetting.ts
+++ b/vtc-service/admin-ui/src/lib/vetting.ts
@@ -8,15 +8,19 @@
 // trail, or to write a policy — can still find it.
 //
 // It also mirrors the checks the daemon runs on what the console sends, so a
-// form can say what is wrong before a request is refused:
+// form can say what is wrong before a request is refused. The shapes are the
+// published specifications' (`wire-types.ts`); the daemon checks each against
+// its schema, plus the rules a schema cannot state
+// (`vta_sdk::protocols::vetting::CheckShape`):
 //
-//   - `validateRequirements` is `VettingRequirements::validate` plus the serde
-//     rules on its members (`vta-sdk/src/protocols/vetting.rs`).
-//   - `validateBranding` is `CommunityBranding::check_shape`
-//     (`vta-sdk/src/protocols/join_requests.rs`).
-//   - `buildListBody` is `VetterListBody::check_shape`.
+//   - `validateRequirements` is the `VettingRequirements` definition of
+//     `vtc/join-requests/manifest/0.2`, plus its rule that every `minByMethod`
+//     method is accepted.
+//   - `validateBranding` is that manifest's `CommunityBranding` definition.
+//   - `buildListBody` is `vtc/vetting/vetters/list/0.1`'s payload, plus its
+//     rule that `eventTo` is not before `eventFrom`.
 //   - the grant and sweep bounds are `MIN_/MAX_VETTER_GRANT_VALIDITY_SECONDS`
-//     and `MIN_/MAX_AUTO_GRANT_SWEEP_MINUTES`.
+//     (the grant schema's own) and `MIN_/MAX_AUTO_GRANT_SWEEP_MINUTES`.
 //
 // The daemon stays the authority: it runs every one of these again, and makes
 // the one check this module cannot — that a `statementType` is a registered
@@ -29,8 +33,12 @@ import type {
   VetterGrantRow,
   VetterListBody,
   VettingMethod,
+  VettingRelationship,
+  VettingRequirements,
   VettingRevocationRow,
 } from "@/lib/wire-types";
+
+export type { VettingRequirements };
 
 // ── Methods and relationships ───────────────────────────────────────────
 
@@ -65,14 +73,16 @@ export function methodLabel(method: string): string {
   return isVettingMethod(method) ? METHOD_LABELS[method] : method;
 }
 
-export const DECLARED_RELATIONSHIPS = [
+/** A vetter's declared relationship to the applicant. */
+export type DeclaredRelationship = VettingRelationship;
+
+export const DECLARED_RELATIONSHIPS: readonly DeclaredRelationship[] = [
   "none",
   "communityColleague",
   "sameEmployer",
   "family",
   "otherPersonal",
-] as const;
-export type DeclaredRelationship = (typeof DECLARED_RELATIONSHIPS)[number];
+];
 
 const RELATIONSHIP_LABELS: Record<DeclaredRelationship, string> = {
   none: "No prior relationship",
@@ -334,33 +344,10 @@ export function describeSeconds(total: number): string {
 }
 
 // ── Vetting requirements (manifest 0.2) ─────────────────────────────────
-
-/**
- * A criterion's `vetting` object. The daemon publishes this member as an
- * opaque object in its OpenAPI document (`value_type = Object`), so there is no
- * generated type to alias: it is read as `unknown`, and `validateRequirements`
- * is what makes it this shape.
- */
-export interface VettingRequirements {
-  version: string;
-  statementType: string;
-  minStatements: number;
-  minByMethod?: Partial<Record<VettingMethod, number>>;
-  acceptedMethods: VettingMethod[];
-  acceptedDocumentClasses?: string[];
-  requiredClaims?: string[];
-  optionalClaims?: string[];
-  maxStatementAge?: string;
-  eligibleVetters: { role: string };
-  independence?: {
-    maxByDeclaredRelationship?: Partial<Record<DeclaredRelationship, number>>;
-    requireConsistentIdentityCommitment?: boolean;
-  };
-  invitation?: "required" | "optional" | "none";
-  decisionSla?: string;
-  requirementsGrace?: string;
-  governanceFrameworkUrl?: string;
-}
+//
+// `VettingRequirements` is the manifest specification's own definition,
+// aliased in `wire-types.ts`. `validateRequirements` still takes `unknown`: it
+// reports on a criterion stored before a rule existed, which need not match.
 
 const isObject = (v: unknown): v is Record<string, unknown> =>
   typeof v === "object" && v !== null && !Array.isArray(v);

--- a/vtc-service/admin-ui/src/lib/vetting.ts
+++ b/vtc-service/admin-ui/src/lib/vetting.ts
@@ -352,6 +352,34 @@ export function describeSeconds(total: number): string {
 const isObject = (v: unknown): v is Record<string, unknown> =>
   typeof v === "object" && v !== null && !Array.isArray(v);
 const chars = (s: string) => [...s].length;
+
+/** Characters RFC 3986 allows in a URI. */
+const URI_CHARACTERS = /^[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=%-]*$/;
+
+export type HttpsUriProblem = "whitespace" | "length" | "notHttpsUri";
+
+/**
+ * What stops `value` being a member the manifest and vetter schemas give
+ * `format: uri`, `^https://` and `maxLength: 2048` — an absolute https URI with
+ * a host — or `null`. Mirrors `shape::https_uri`: the schema validator does not
+ * assert `format`, so the daemon checks it by hand and so does the console.
+ */
+export function httpsUriProblem(value: string): HttpsUriProblem | null {
+  if (/[\s\u0000-\u001f\u007f-\u009f]/.test(value)) return "whitespace";
+  if (chars(value) > 2048) return "length";
+  const rest = value.startsWith("https://") ? value.slice("https://".length) : null;
+  if (rest === null || rest === "" || /^[/?#]/.test(rest)) return "notHttpsUri";
+  if (!URI_CHARACTERS.test(value) || /%(?![0-9A-Fa-f]{2})/.test(value)) {
+    return "notHttpsUri";
+  }
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" && parsed.hostname ? null : "notHttpsUri";
+  } catch {
+    return "notHttpsUri";
+  }
+}
+
 const isCount = (v: unknown): v is number =>
   typeof v === "number" && Number.isInteger(v) && v >= 0 && v <= 4_294_967_295;
 const isStringArray = (v: unknown): v is string[] =>
@@ -462,13 +490,9 @@ export function validateRequirements(value: unknown): string[] {
 
   if (v.governanceFrameworkUrl !== undefined) {
     const url = v.governanceFrameworkUrl;
-    if (
-      typeof url !== "string" ||
-      !url.startsWith("https://") ||
-      chars(url) > 2048
-    ) {
+    if (typeof url !== "string" || httpsUriProblem(url) !== null) {
       problems.push(
-        "The governance framework address must be an https:// URL of at most 2048 characters.",
+        "The governance framework address must be a complete https:// URL of at most 2048 characters, with no spaces.",
       );
     }
   }
@@ -800,15 +824,19 @@ export function validateBranding(draft: BrandingDraft): BrandingErrors {
   }
   const url = draft.logoUrl.trim();
   if (url) {
+    const problem = httpsUriProblem(url);
     if (!url.startsWith("https://")) {
       errors.logoUrl =
         "Use an https:// address. Clients refuse to fetch a logo over plain http.";
     } else if (url.length <= "https://".length) {
       errors.logoUrl = "Add the rest of the address after https://.";
-    } else if (/[\s\u0000-\u001f\u007f-\u009f]/.test(url)) {
-      errors.logoUrl = "Remove the spaces from the logo address.";
-    } else if (chars(url) > 2048) {
+    } else if (problem === "whitespace") {
+      errors.logoUrl = "Remove the spaces and control characters from the logo address.";
+    } else if (problem === "length") {
       errors.logoUrl = `The address is ${chars(url)} characters. Use one of 2048 or fewer.`;
+    } else if (problem === "notHttpsUri") {
+      errors.logoUrl =
+        "Enter a complete address, like https://example.org/logo.svg, with other characters percent-encoded.";
     }
   }
   return errors;

--- a/vtc-service/admin-ui/src/lib/wire-types.ts
+++ b/vtc-service/admin-ui/src/lib/wire-types.ts
@@ -56,27 +56,34 @@ export type RemovedMemberRow = Schemas["RemovedMember"];
 export type RemovedMembersResponse = Schemas["RemovedMembersResponse"];
 export type EndorsementRow = Schemas["EndorsementRow"];
 export type EndorsementsPage = Schemas["Paginated_EndorsementRow"];
-export type VetterGrantResponse = Schemas["VetterGrantResponseBody"];
+export type VetterGrantResponse = Schemas["VtcVettingVettersGrantV0_1Response"];
 
 // ── Vetter registry (admin) ─────────────────────────────────────────────
+//
+// The Trust Task bodies below are the published specifications' own: their
+// schemas are named `<slug><version><definition>` and rendered from the schema
+// each generated type embeds, not described by hand.
 export type VetterGrantList = Schemas["VetterGrantListResponse"];
 export type VetterGrantRow = Schemas["VetterGrantRow"];
 export type VetterProfileSummary = Schemas["VetterProfileSummary"];
 export type VetterGrantOrigin = Schemas["GrantOrigin"];
-export type VetterResendResponse = Schemas["VetterResendResponseBody"];
+export type VetterResendResponse = Schemas["VtcVettingVettersResendV0_1Response"];
 export type AutoGrantStatus = Schemas["AutoGrantStatus"];
 export type AutoGrantConfig = Schemas["AutoGrantConfig"];
 export type AutoGrantSweep = Schemas["AutoGrantSweep"];
 export type VettingRevocationList = Schemas["VettingRevocationListResponse"];
 export type VettingRevocationRow = Schemas["VettingRevocationRow"];
 export type RevocationReviewState = Schemas["RevocationReviewState"];
-export type VettingMethod = Schemas["VettingMethod"];
-export type VetterListBody = Schemas["VetterListBody"];
-export type VetterListResponse = Schemas["VetterListResponseBody"];
-export type ListedVetter = Schemas["ListedVetter"];
-export type VetterEvent = Schemas["VetterEvent"];
-export type VetterLocation = Schemas["VetterLocation"];
-export type CommunityBranding = Schemas["CommunityBranding"];
+/** The vetting vocabulary, as `vtc/join-requests/manifest/0.2` defines it. */
+export type VettingMethod = Schemas["VtcJoinRequestsManifestV0_2VettingMethod"];
+export type VettingRelationship = Schemas["VtcJoinRequestsManifestV0_2VettingRelationship"];
+export type VetterListBody = Schemas["VtcVettingVettersListV0_1Payload"];
+export type VetterListResponse = Schemas["VtcVettingVettersListV0_1Response"];
+export type ListedVetter = Schemas["VtcVettingVettersListV0_1ListedVetter"];
+export type VetterEvent = Schemas["VtcVettingVettersListV0_1VetterEvent"];
+export type VetterLocation = Schemas["VtcVettingVettersListV0_1VetterLocation"];
+/** `vtc/join-requests/manifest/0.2`'s branding — also the body of `/v1/community/branding`. */
+export type CommunityBranding = Schemas["VtcJoinRequestsManifestV0_2CommunityBranding"];
 export type RequestVmcResponse = Schemas["RequestVmcResponse"];
 
 // ── Join requests ───────────────────────────────────────────────────────
@@ -86,8 +93,9 @@ export type JoinRequestsPage = Schemas["Paginated_JoinRequest"];
 export type JoinRequestVettingResponse = Schemas["JoinRequestVettingResponse"];
 export type JoinRequestVetting = Schemas["JoinRequestVetting"];
 export type JoinRequestVettingStatement = Schemas["JoinRequestVettingStatement"];
-export type JoinManifest = Schemas["JoinRequestManifestResponseBody"];
-export type ManifestCriterion = Schemas["ManifestCriterion"];
+export type JoinManifest = Schemas["VtcJoinRequestsManifestV0_2Response"];
+export type ManifestCriterion = Schemas["VtcJoinRequestsManifestV0_2Criterion"];
+export type VettingRequirements = Schemas["VtcJoinRequestsManifestV0_2VettingRequirements"];
 export type DecideResponse = Schemas["DecideResponse"];
 
 // ── Audit ───────────────────────────────────────────────────────────────

--- a/vtc-service/admin-ui/src/lib/wire.ts
+++ b/vtc-service/admin-ui/src/lib/wire.ts
@@ -1787,14 +1787,7 @@ export interface components {
              *     [`validate_accepts_query`]).
              */
             query: unknown;
-            /**
-             * @description Peer identity vetting this criterion requires, advertised to applicants
-             *     in the join manifest (0.2). Every number in it is this community's
-             *     policy. Checked by [`VettingRequirements::validate`] when stored; the
-             *     admin route additionally requires its `statementType` to be a registered
-             *     endorsement type.
-             */
-            vetting?: Record<string, never> | null;
+            vetting?: null | components["schemas"]["VtcJoinRequestsManifestV0_2VettingRequirements"];
         };
         /**
          * @description `{ entry: … }` — the shape `acl/{grant,show,change-role}/0.1` publish.
@@ -2172,21 +2165,6 @@ export interface components {
              *     registration state.
              */
             registrationId: string;
-        };
-        /**
-         * @description A community's presentation — `join-requests/manifest/0.2`'s `branding`, and
-         *     the body of the VTC's `GET`/`PUT /v1/community/branding`. Every member is
-         *     optional. Presentation only: a client never trusts a community because of
-         *     how it is branded.
-         */
-        CommunityBranding: {
-            /** @description `#rrggbb`. */
-            accentColor?: string | null;
-            /** @description The name to show; 1–128 characters. */
-            displayName?: string | null;
-            ext?: null | components["schemas"]["Value"];
-            /** @description An `https` URL of at most 2048 characters. */
-            logoUrl?: string | null;
         };
         /**
          * @description The singleton record. Field names are wire contract — operators
@@ -3175,12 +3153,6 @@ export interface components {
         JoinRequestEnvelope: {
             request: components["schemas"]["JoinRequest"];
         };
-        /** @description Manifest response: the community's join evidence requirements. */
-        JoinRequestManifestResponseBody: {
-            branding?: null | components["schemas"]["CommunityBranding"];
-            communityDid: string;
-            criteria: components["schemas"]["ManifestCriterion"][];
-        };
         /**
          * @description The vetting facts a join request was decided on — the policy's
          *     `input.evidence.vetting`, in lowerCamelCase.
@@ -3341,59 +3313,6 @@ export interface components {
              *     not define, so no conforming client could find it.
              */
             credentials: components["schemas"]["RegisteredCredential"][];
-        };
-        /**
-         * @description One vetter in a listing: the published profile, the DID and the grant's
-         *     expiry — nothing else about the member.
-         */
-        ListedVetter: {
-            /** @description See [`VetterProfileBody::accepts_documentation`]. */
-            acceptsDocumentation: string[];
-            /** @description See [`VetterProfileBody::availability`]. */
-            availability?: string | null;
-            /** @description See [`VetterProfileBody::contact_hint`]. */
-            contactHint?: string | null;
-            /** @description See [`VetterProfileBody::display_name`]. */
-            displayName?: string | null;
-            /** @description The profile's events that have not ended (`endDate` ≥ today, UTC). */
-            events: components["schemas"]["VetterEvent"][];
-            /**
-             * Format: date-time
-             * @description When the vetter's grant expires.
-             */
-            grantValidUntil: string;
-            /** @description See [`VetterProfileBody::languages`]. */
-            languages: string[];
-            location?: null | components["schemas"]["VetterLocation"];
-            /** @description See [`VetterProfileBody::methods`]. */
-            methods: components["schemas"]["VettingMethod"][];
-            /**
-             * Format: date-time
-             * @description When the profile was last published.
-             */
-            updatedAt: string;
-            /** @description The vetter's DID — where a `vetting/request` goes. */
-            vetterDid: string;
-        };
-        /**
-         * @description One community evidence requirement — a named DCQL Presentation
-         *     Definition the applicant may present against.
-         */
-        ManifestCriterion: {
-            description?: string | null;
-            id: string;
-            presentationDefinition: components["schemas"]["Value"];
-            /**
-             * @description `digestMultibase` over this criterion without this member (manifest
-             *     0.2). An applicant records it when it starts gathering, so a change to
-             *     the requirements mid-application is detectable.
-             */
-            requirementsDigest?: string | null;
-            /**
-             * @description Peer identity vetting this criterion requires (manifest 0.2). Absent on
-             *     a criterion that needs none.
-             */
-            vetting?: Record<string, never> | null;
         };
         /**
          * @description `{ member: … }` — the shape `vtc/members/show/0.1` publishes. The row was
@@ -4220,11 +4139,7 @@ export interface components {
             description?: string | null;
             id: string;
             query: components["schemas"]["Value"];
-            /**
-             * @description Peer identity vetting this criterion requires, advertised in the join
-             *     manifest (0.2). Its `statementType` must be a registered endorsement type.
-             */
-            vetting?: Record<string, never> | null;
+            vetting?: null | components["schemas"]["VtcJoinRequestsManifestV0_2VettingRequirements"];
         };
         RegisterBody: {
             claimSchema?: null | components["schemas"]["Value"];
@@ -4980,65 +4895,10 @@ export interface components {
             /** @description Whether every chainable envelope verified. */
             verified: boolean;
         };
-        /** @description An event a vetter will attend and vet at — a conference, a summit. */
-        VetterEvent: {
-            /**
-             * Format: date
-             * @description Last day, `YYYY-MM-DD`; not before `startDate`, at most 31 days after it.
-             */
-            endDate: string;
-            location?: null | components["schemas"]["VetterLocation"];
-            /** @description The event's name; 1–200 characters. */
-            name: string;
-            /**
-             * Format: date
-             * @description First day, `YYYY-MM-DD`.
-             */
-            startDate: string;
-            /** @description The event's page; `https`, at most 2048 characters. */
-            url?: string | null;
-        };
-        /** @description `vtc/vetting/vetters/grant/0.1` payload. */
-        VetterGrantBody: {
-            /** @description Ecosystem-defined extension members (SPEC §4.5.1). */
-            ext?: unknown;
-            /** @description The member to name as a vetter. */
-            memberDid: string;
-            /**
-             * Format: int64
-             * @description How long the grant is valid, from one day to two years; one year when
-             *     absent.
-             */
-            validitySeconds?: number | null;
-        };
         /** @description `GET /v1/vetting/vetters` response: every grant, newest first. */
         VetterGrantListResponse: {
             /** @description The grants. */
             vetters: components["schemas"]["VetterGrantRow"][];
-        };
-        /**
-         * @description `vtc/vetting/vetters/grant/0.1#response` payload.
-         *
-         *     Granting converges: while a grant is live and unexpired, asking again
-         *     returns it rather than issuing a second.
-         */
-        VetterGrantResponseBody: {
-            /** @description The vetter role credential's `id`. */
-            credentialId: string;
-            /** @description The community's record of the grant — the id its revocation names. */
-            endorsementId: string;
-            /** @description Ecosystem-defined extension members (SPEC §4.5.1). */
-            ext?: unknown;
-            /**
-             * Format: date-time
-             * @description The credential's `validFrom`.
-             */
-            validFrom: string;
-            /**
-             * Format: date-time
-             * @description The credential's `validUntil`.
-             */
-            validUntil: string;
         };
         /** @description One vetter grant, as `GET /v1/vetting/vetters` reports it. */
         VetterGrantRow: {
@@ -5074,68 +4934,6 @@ export interface components {
              */
             validUntil?: string | null;
         };
-        /**
-         * @description `vtc/vetting/vetters/list/0.1` payload. Every filter is optional; filters
-         *     combine with AND.
-         */
-        VetterListBody: {
-            /** @description Case-insensitive exact match on `location.city`. */
-            city?: string | null;
-            /** @description ISO 3166-1 alpha-2, uppercase. */
-            country?: string | null;
-            /** @description The `nextCursor` of the previous page; at most 512 characters. */
-            cursor?: string | null;
-            /**
-             * Format: date
-             * @description With `eventTo`, a date range a listed event must overlap; an open end is
-             *     unbounded.
-             */
-            eventFrom?: string | null;
-            /**
-             * @description Case-insensitive substring of a listed event's name; at most 200
-             *     characters.
-             */
-            eventName?: string | null;
-            /**
-             * Format: date
-             * @description See [`Self::event_from`].
-             */
-            eventTo?: string | null;
-            /** @description Ecosystem-defined extension members (SPEC §4.5.1). */
-            ext?: unknown;
-            /**
-             * @description A BCP 47 tag. Matches a listed tag equal to it, or one it is a prefix of
-             *     at a subtag boundary (`de` matches `de-AT`). Compared case-insensitively.
-             */
-            language?: string | null;
-            /**
-             * Format: int32
-             * @description Page size, 1–100; 50 when absent.
-             */
-            limit?: number | null;
-            method?: null | components["schemas"]["VettingMethod"];
-            /** @description Case-insensitive exact match on `location.region`. */
-            region?: string | null;
-        };
-        /** @description `vtc/vetting/vetters/list/0.1#response` payload. */
-        VetterListResponseBody: {
-            /**
-             * @description Pass as `cursor`, with the same filters, for the next page; absent on
-             *     the last.
-             */
-            nextCursor?: string | null;
-            /** @description This page, in the listing's order. */
-            vetters: components["schemas"]["ListedVetter"][];
-        };
-        /** @description Where a vetter is, or where an event is held. */
-        VetterLocation: {
-            /** @description City; 1–128 characters. */
-            city?: string | null;
-            /** @description ISO 3166-1 alpha-2, uppercase. */
-            country: string;
-            /** @description Region, state or province; 1–128 characters. */
-            region?: string | null;
-        };
         /** @description What an admin sees of a vetter's published profile. */
         VetterProfileSummary: {
             /** @description The profile's `location.country`. */
@@ -5152,31 +4950,13 @@ export interface components {
             /** @description Whether the profile appears in listings. */
             listed: boolean;
             /** @description The profile's `methods`. */
-            methods?: components["schemas"]["VettingMethod"][];
+            methods?: components["schemas"]["VtcVettingVettersProfileV0_1VettingMethod"][];
             /**
              * Format: date-time
              * @description When the profile was last published.
              */
             updatedAt: string;
         };
-        /**
-         * @description `vtc/vetting/vetters/resend/0.1#response` payload — also the answer to the
-         *     admin `POST /v1/vetting/vetters/{memberDid}/resend`.
-         */
-        VetterResendResponseBody: {
-            /** @description The re-delivered credential's `id`. */
-            credentialId: string;
-            /**
-             * Format: date-time
-             * @description Its `validUntil`.
-             */
-            validUntil: string;
-        };
-        /**
-         * @description How a vetter established who the applicant is.
-         * @enum {string}
-         */
-        VettingMethod: "inPerson" | "video" | "priorAcquaintance";
         /** @description `GET /v1/vetting/revocations` response: every notice, newest first. */
         VettingRevocationListResponse: {
             /** @description The notices. */
@@ -5208,10 +4988,331 @@ export interface components {
             statementId: string;
         };
         /**
+         * @description The vocabulary token naming what a value IS — `name.legal`, `phone.mobile`, `address.postal`, `person.birthDate`. Dotted, most-general segment first, so that a consumer with no knowledge of the specific token can still group by its prefix.
+         *
+         *     The token is the maintainer's own; no external vocabulary is primary. External vocabularies (vCard/jCard, OIDC standard claims, schema.org) are mappings applied at PRESENTATION by a renderer, not at rest, so that a query written in any of them can be matched without the store having to live inside any one of them.
+         *
+         *     The `x:` prefix is an open extension namespace and is not decoration. The closest prior art — Windows CardSpace's self-issued card — supported exactly fifteen predefined claim types with no extensibility, and that is the specific way it failed the requirement a holder actually has. An `x:` attribute stores, composes, binds and discloses exactly like a known one; it renders generically and matches only an explicit query.
+         */
+        VtcJoinRequestsManifestV0_2ClaimType: string;
+        /** @description OPTIONAL. How the community asks to be shown to a prospective applicant: a name, an accent colour and a logo. Presentation only, self-asserted and unverified — `communityDid` identifies the community, never `branding`. Not part of any criterion, so not covered by a `requirementsDigest`. Every member is optional. */
+        VtcJoinRequestsManifestV0_2CommunityBranding: {
+            /** @description An sRGB colour as `#rrggbb`, compared case-insensitively. A community SHOULD write it in lower case. */
+            accentColor?: string;
+            /** @description The community's name as it asks to be shown. */
+            displayName?: string;
+            ext?: components["schemas"]["VtcJoinRequestsManifestV0_2Ext"];
+            /**
+             * Format: uri
+             * @description An https URL of the community's logo. Fetched by the client, so an untrusted image from wherever it points.
+             */
+            logoUrl?: string;
+        };
+        VtcJoinRequestsManifestV0_2Criterion: {
+            /** @description Plain-language summary of the criterion, authored by the community and shown to prospective applicants. Informative: where it and `vetting` disagree, `vetting` governs. */
+            description?: string;
+            id: string;
+            /** @description The presentation-definition an applicant must satisfy for this criterion (opaque here). */
+            presentationDefinition: Record<string, never>;
+            requirementsDigest?: components["schemas"]["VtcJoinRequestsManifestV0_2DigestMultibase"];
+            vetting?: components["schemas"]["VtcJoinRequestsManifestV0_2VettingRequirements"];
+        };
+        /**
+         * @description A cryptographic digest as a multibase-encoded multihash — the encoding the W3C Verifiable Credentials Data Model 2.0 defines for `digestMultibase`, and the one `did:webvh` uses for its SCID and entry hashes.
+         *
+         *     Multihash carries the hash algorithm in-band, so the value is self-describing and the wire format survives an algorithm change without a schema revision; multibase does the same for the base encoding, so a verifier never infers base58 from base64url by context. A bare hex string or a `sha-256:`-style prefix hard-codes one algorithm into the wire contract and is non-conforming here.
+         *
+         *     This definition constrains the *encoding only*. What the digest is computed over is stated by each referencing field, because it differs legitimately: a digest over a JSON document is taken over its RFC 8785 (JCS) canonicalization, while a digest over an opaque artifact is taken over its bytes. A field whose input is a JSON document and which does not name a canonicalization is not reproducible.
+         *
+         *     Restricted to the two multibase headers W3C Controlled Identifiers 1.0 §2.4 normatively requires — `z` (base58btc) and `u` (base64url-no-pad). CID permits others but states that "interoperability is not guaranteed between implementations using such values", and a registry whose purpose is interoperability should not mint digests a conforming verifier may be unable to read. The alphabets are enforced rather than assumed: base58btc excludes 0, O, I and l, and an earlier permissive pattern let three published examples carry digests that were not valid base58 at all. base58btc is RECOMMENDED, for consistency with `did:key` and `did:webvh`.
+         */
+        VtcJoinRequestsManifestV0_2DigestMultibase: string;
+        /** @description An ISO 8601 duration in weeks, days, hours, minutes and seconds only (e.g. `P120D`, `P2W`, `P1DT12H`, `PT15M`). Years and months are refused: their length depends on the calendar, and an age limit that means different things on different days is not a limit. */
+        VtcJoinRequestsManifestV0_2Duration: string;
+        /** @description Vendor-namespaced extension object per SPEC.md §4.5.1. Each immediate key MUST be a reverse-DNS namespace; structure under each namespace is opaque to the framework. */
+        VtcJoinRequestsManifestV0_2Ext: {
+            [key: string]: unknown;
+        };
+        VtcJoinRequestsManifestV0_2Response: {
+            branding?: components["schemas"]["VtcJoinRequestsManifestV0_2CommunityBranding"];
+            communityDid: string;
+            criteria: components["schemas"]["VtcJoinRequestsManifestV0_2Criterion"][];
+            ext?: components["schemas"]["VtcJoinRequestsManifestV0_2Ext"];
+        };
+        /** @description A class of documentation, named in lowerCamelCase. Open rather than enumerated, because what documentation a vetter accepts is each vetter's own choice. Well-known values: `passport`, `nationalId`, `driverLicence`, and `none` — the vetter will attest without a document, which is the `priorAcquaintance` case. Only the class ever travels — never a document number, an image, an issuing authority or an expiry date. `none` states a policy (what a vetter accepts); a record of what was relied on expresses 'no document' as an empty list instead. */
+        VtcJoinRequestsManifestV0_2VettingDocumentation: string;
+        /**
+         * @description How the vetter established that the person they checked is the person controlling the applicant's DID. `inPerson` — both people were physically together. `video` — a live, two-way video call. `priorAcquaintance` — the vetter has known or worked with this person over a period, and attests from that knowledge rather than from a document. A method is a description of what happened, not an assurance level: which methods count, and how many of each, is community policy.
+         * @enum {string}
+         */
+        VtcJoinRequestsManifestV0_2VettingMethod: "inPerson" | "video" | "priorAcquaintance";
+        /**
+         * @description The vetter's own declaration of how they relate to the applicant. Declared, not verified: it exists so community policy can cap how much evidence comes from people close to the applicant, and a false declaration is the vetter's attributable act.
+         * @enum {string}
+         */
+        VtcJoinRequestsManifestV0_2VettingRelationship: "none" | "communityColleague" | "sameEmployer" | "family" | "otherPersonal";
+        /** @description What identity-vetting evidence a criterion needs, beyond what a presentation-definition can express: distinct eligible vetters, per-method floors, independence caps. Every number is the community's own policy. This schema supplies no defaults — an absent optional member means the community imposes no constraint of that kind, never that some protocol value applies. Deliberately open: a consumer MUST ignore members it does not recognise, so a community publishing a newer shape does not make an older client unable to read the rest. Durations: `maxStatementAge` — a statement older than this at decision time does not count (absent: no limit beyond the statement's own validity); `decisionSla` — how long after submission the community undertakes to decide, including on a referred application; `requirementsGrace` — how long an application started under an earlier `requirementsDigest` is still evaluated under that version. */
+        VtcJoinRequestsManifestV0_2VettingRequirements: {
+            /** @description Documentation a statement must have relied on in order to count. Absent — the expected case — means each vetter decides what documentation they accept, including none for prior acquaintance, and the community counts what they attest. */
+            acceptedDocumentClasses?: components["schemas"]["VtcJoinRequestsManifestV0_2VettingDocumentation"][];
+            /** @description Methods whose statements count at all. */
+            acceptedMethods: components["schemas"]["VtcJoinRequestsManifestV0_2VettingMethod"][];
+            decisionSla?: components["schemas"]["VtcJoinRequestsManifestV0_2Duration"];
+            /** @description How a vetter's eligibility is established. */
+            eligibleVetters: {
+                /** @description The role named in a community-issued `CommunityRole` endorsement credential (see `vtc/vetting/vetters/grant/0.1`). A statement counts only if its issuer holds that credential. */
+                role: string;
+            };
+            /**
+             * Format: uri
+             * @description Where the community's vetting governance — including the attestation text vetters sign — is published.
+             */
+            governanceFrameworkUrl?: string;
+            /** @description Caps on how much evidence may come from people close to the applicant. Absent: no caps. */
+            independence?: {
+                /** @description The most counted statements that may come from vetters declaring each relationship — e.g. `{ "family": 0 }`. */
+                maxByDeclaredRelationship?: {
+                    [key: string]: number;
+                };
+                /** @description When true, every counted statement must carry the same identity commitment — all vetters verified the same claimed identity. Absent: false. */
+                requireConsistentIdentityCommitment?: boolean;
+            };
+            /**
+             * @description Whether an invitation credential must accompany the statements at submission (`required`), may (`optional`), or plays no part (`none`). Absent: the presentation-definition alone governs.
+             * @enum {string}
+             */
+            invitation?: "required" | "optional" | "none";
+            maxStatementAge?: components["schemas"]["VtcJoinRequestsManifestV0_2Duration"];
+            /** @description Per-method floors within `minStatements` — e.g. `{ "inPerson": 1 }`. Every method named MUST also be in `acceptedMethods`. Absent: no method floor. */
+            minByMethod?: {
+                [key: string]: number;
+            };
+            /** @description How many counted statements are needed, counting each vetter once however many DIDs they hold. */
+            minStatements: number;
+            /** @description Claim types an applicant MAY add to the card and a vetter MAY verify. They never affect whether a statement counts. */
+            optionalClaims?: components["schemas"]["VtcJoinRequestsManifestV0_2ClaimType"][];
+            /** @description Claim types the applicant's Vetting Card must carry, which the identity commitment is computed over, and which a counted statement must list as verified. Absent: none. */
+            requiredClaims?: components["schemas"]["VtcJoinRequestsManifestV0_2ClaimType"][];
+            requirementsGrace?: components["schemas"]["VtcJoinRequestsManifestV0_2Duration"];
+            /**
+             * Format: uri
+             * @description The endorsement type URI a counted vetting statement carries as `credentialSubject.endorsement.type`, as registered with the community via vtc/endorsement-types/register.
+             */
+            statementType: string;
+            /** @description Version of this requirements object's shape. `0.1` for the members defined here. */
+            version: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * @description One of `admin`, `moderator`, `issuer`, `member`, or                  `custom:<name>` where `<name>` is 1..=64 lowercase                  alphanumerics, `-`, or `_`.
          * @example admin
          */
         VtcRole: string;
+        /** @description Vendor-namespaced extension object per SPEC.md §4.5.1. Each immediate key MUST be a reverse-DNS namespace; structure under each namespace is opaque to the framework. */
+        VtcVettingVettersGrantV0_1Ext: {
+            [key: string]: unknown;
+        };
+        /** @description A community administrator makes a member a vetter. The community issues the member a revocable `CommunityRole` endorsement credential for the `vetter` role, delivers it over credential-exchange/issue, and returns the identifiers and validity of the grant. A member who already holds a live grant gets that grant back unchanged. */
+        VtcVettingVettersGrantV0_1Payload: {
+            ext?: components["schemas"]["VtcVettingVettersGrantV0_1Ext"];
+            /** @description The member DID to grant the vetter role to — the subject of the role credential, and the DID the vetter signs statements with. */
+            memberDid: string;
+            /** @description OPTIONAL. How long the role credential is valid, from issuance: at least one day, at most two years. Absent: 31536000 (365 days). Ignored when the member already holds a live grant. */
+            validitySeconds?: number;
+        };
+        /** @description The grant — newly issued, or the member's existing live grant. */
+        VtcVettingVettersGrantV0_1Response: {
+            /** @description The `id` of the role credential, a URI. */
+            credentialId: string;
+            /** @description The community's endorsement record for this grant — the identifier vtc/endorsements/revoke takes. */
+            endorsementId: string;
+            ext?: components["schemas"]["VtcVettingVettersGrantV0_1Ext"];
+            /**
+             * Format: date-time
+             * @description The role credential's `validFrom`.
+             */
+            validFrom: string;
+            /**
+             * Format: date-time
+             * @description The role credential's `validUntil`.
+             */
+            validUntil: string;
+        };
+        /**
+         * Format: date
+         * @description A calendar date, `YYYY-MM-DD` (RFC 3339 full-date), with no time or zone. Compared as a UTC date.
+         */
+        VtcVettingVettersListV0_1CalendarDate: string;
+        /** @description An ISO 3166-1 alpha-2 country code, upper case, e.g. `DE`. */
+        VtcVettingVettersListV0_1CountryCode: string;
+        /** @description Vendor-namespaced extension object per SPEC.md §4.5.1. Each immediate key MUST be a reverse-DNS namespace; structure under each namespace is opaque to the framework. */
+        VtcVettingVettersListV0_1Ext: {
+            [key: string]: unknown;
+        };
+        /** @description A BCP 47 language tag, e.g. `en`, `de-AT`. Compared case-insensitively. */
+        VtcVettingVettersListV0_1LanguageTag: string;
+        /** @description One listed vetter: the published profile without `listed` and `ext`, the vetter's DID, the expiry of their live grant, and when the profile was stored. Nothing else about the member is disclosed. */
+        VtcVettingVettersListV0_1ListedVetter: {
+            acceptsDocumentation: components["schemas"]["VtcVettingVettersListV0_1VetterAcceptsDocumentation"];
+            availability?: components["schemas"]["VtcVettingVettersListV0_1VetterAvailability"];
+            contactHint?: components["schemas"]["VtcVettingVettersListV0_1VetterContactHint"];
+            displayName?: components["schemas"]["VtcVettingVettersListV0_1VetterDisplayName"];
+            /** @description The profile's events whose `endDate` is today (UTC) or later. Ended events are never returned. */
+            events: components["schemas"]["VtcVettingVettersListV0_1VetterEvent"][];
+            /**
+             * Format: date-time
+             * @description The `validUntil` of the vetter's live vetter role credential.
+             */
+            grantValidUntil: string;
+            languages: components["schemas"]["VtcVettingVettersListV0_1LanguageTag"][];
+            location?: components["schemas"]["VtcVettingVettersListV0_1VetterLocation"];
+            methods: components["schemas"]["VtcVettingVettersListV0_1VetterMethods"];
+            /**
+             * Format: date-time
+             * @description When the community stored this profile, as returned by vtc/vetting/vetters/profile.
+             */
+            updatedAt: string;
+            /** @description The vetter's member DID — the subject of their vetter role credential, and the DID a vetting/request is addressed to. */
+            vetterDid: string;
+        };
+        /** @description An authenticated applicant or member asks a community for its listed vetters, optionally filtered by language, location, method or event. Only active members with a live vetter grant and a profile stored with `listed: true` appear, and each entry carries only what the vetter published, their DID and their grant's expiry. Every filter is optional; filters combine with AND. */
+        VtcVettingVettersListV0_1Payload: {
+            city?: components["schemas"]["VtcVettingVettersListV0_1PlaceName"];
+            country?: components["schemas"]["VtcVettingVettersListV0_1CountryCode"];
+            /** @description Opaque continuation token from a previous page's `nextCursor`, sent with the same filters. */
+            cursor?: string;
+            eventFrom?: components["schemas"]["VtcVettingVettersListV0_1CalendarDate"];
+            /** @description Matches an event whose `name` contains this text, case-insensitively. */
+            eventName?: string;
+            eventTo?: components["schemas"]["VtcVettingVettersListV0_1CalendarDate"];
+            ext?: components["schemas"]["VtcVettingVettersListV0_1Ext"];
+            language?: components["schemas"]["VtcVettingVettersListV0_1LanguageTag"];
+            /** @description Most entries to return. Absent: 50. */
+            limit?: number;
+            method?: components["schemas"]["VtcVettingVettersListV0_1VettingMethod"];
+            region?: components["schemas"]["VtcVettingVettersListV0_1PlaceName"];
+        };
+        /** @description A region or city name as the vetter writes it. Compared case-insensitively and otherwise exactly. */
+        VtcVettingVettersListV0_1PlaceName: string;
+        /** @description One page of listed vetters matching every filter sent. */
+        VtcVettingVettersListV0_1Response: {
+            /** @description Present when more entries match; send it as `cursor`, with the same filters, for the next page. Absent on the last page. */
+            nextCursor?: string;
+            /** @description The page, in the order Conformance defines. May be empty. */
+            vetters: components["schemas"]["VtcVettingVettersListV0_1ListedVetter"][];
+        };
+        /** @description What documentation the vetter relies on, in the same tokens as vetting/request's `acceptsDocumentation` — `passport`, `nationalId`, `driverLicence`, `none`, or another lowerCamelCase class. The vetter's own choice; empty says nothing either way. */
+        VtcVettingVettersListV0_1VetterAcceptsDocumentation: components["schemas"]["VtcVettingVettersListV0_1VettingDocumentation"][];
+        /** @description Vetter-authored free text on when they are available to vet. Attributed to the vetter. */
+        VtcVettingVettersListV0_1VetterAvailability: string;
+        /** @description Vetter-authored free text on how to obtain a ticket from them, e.g. `Find me at the OpenVTC booth`. A hint, not an address a request can be sent to: vetting/request still needs a ticket or an introduction the vetter accepts. */
+        VtcVettingVettersListV0_1VetterContactHint: string;
+        /** @description The name the vetter chooses to be listed under. Self-asserted and unverified: it is not the name on any document, and a client MUST attribute it to the vetter. */
+        VtcVettingVettersListV0_1VetterDisplayName: string;
+        /** @description An event the vetter will attend and vet at. `endDate` is on or after `startDate` and no more than 31 days after it; JSON Schema cannot compare two members, so the community checks both and refuses a violation with `malformedRequest`. */
+        VtcVettingVettersListV0_1VetterEvent: {
+            endDate: components["schemas"]["VtcVettingVettersListV0_1CalendarDate"];
+            location?: components["schemas"]["VtcVettingVettersListV0_1VetterLocation"];
+            /** @description The event's name, e.g. `Linux Plumbers Conference 2026`. */
+            name: string;
+            startDate: components["schemas"]["VtcVettingVettersListV0_1CalendarDate"];
+            /**
+             * Format: uri
+             * @description OPTIONAL. The event's own https page.
+             */
+            url?: string;
+        };
+        /** @description Where a vetter can meet people, as coarse as the vetter chooses: a country, optionally a region, optionally a city. Never a street address. */
+        VtcVettingVettersListV0_1VetterLocation: {
+            city?: components["schemas"]["VtcVettingVettersListV0_1PlaceName"];
+            country: components["schemas"]["VtcVettingVettersListV0_1CountryCode"];
+            region?: components["schemas"]["VtcVettingVettersListV0_1PlaceName"];
+        };
+        /** @description The methods the vetter offers, from `inPerson`, `video`, `priorAcquaintance`. */
+        VtcVettingVettersListV0_1VetterMethods: components["schemas"]["VtcVettingVettersListV0_1VettingMethod"][];
+        /** @description A class of documentation, named in lowerCamelCase. Open rather than enumerated, because what documentation a vetter accepts is each vetter's own choice. Well-known values: `passport`, `nationalId`, `driverLicence`, and `none` — the vetter will attest without a document, which is the `priorAcquaintance` case. Only the class ever travels — never a document number, an image, an issuing authority or an expiry date. `none` states a policy (what a vetter accepts); a record of what was relied on expresses 'no document' as an empty list instead. */
+        VtcVettingVettersListV0_1VettingDocumentation: string;
+        /**
+         * @description How the vetter established that the person they checked is the person controlling the applicant's DID. `inPerson` — both people were physically together. `video` — a live, two-way video call. `priorAcquaintance` — the vetter has known or worked with this person over a period, and attests from that knowledge rather than from a document. A method is a description of what happened, not an assurance level: which methods count, and how many of each, is community policy.
+         * @enum {string}
+         */
+        VtcVettingVettersListV0_1VettingMethod: "inPerson" | "video" | "priorAcquaintance";
+        /**
+         * Format: date
+         * @description A calendar date, `YYYY-MM-DD` (RFC 3339 full-date), with no time or zone. Compared as a UTC date.
+         */
+        VtcVettingVettersProfileV0_1CalendarDate: string;
+        /** @description An ISO 3166-1 alpha-2 country code, upper case, e.g. `DE`. */
+        VtcVettingVettersProfileV0_1CountryCode: string;
+        /** @description Vendor-namespaced extension object per SPEC.md §4.5.1. Each immediate key MUST be a reverse-DNS namespace; structure under each namespace is opaque to the framework. */
+        VtcVettingVettersProfileV0_1Ext: {
+            [key: string]: unknown;
+        };
+        /** @description A BCP 47 language tag, e.g. `en`, `de-AT`. Compared case-insensitively. */
+        VtcVettingVettersProfileV0_1LanguageTag: string;
+        /** @description A region or city name as the vetter writes it. Compared case-insensitively and otherwise exactly. */
+        VtcVettingVettersProfileV0_1PlaceName: string;
+        /** @description The community stored the profile. */
+        VtcVettingVettersProfileV0_1Response: {
+            /** @description The stored profile's `listed` value. */
+            listed: boolean;
+            /**
+             * Format: date-time
+             * @description When the community stored this profile. vtc/vetting/vetters/list returns the same value.
+             */
+            updatedAt: string;
+        };
+        /** @description What documentation the vetter relies on, in the same tokens as vetting/request's `acceptsDocumentation` — `passport`, `nationalId`, `driverLicence`, `none`, or another lowerCamelCase class. The vetter's own choice; empty says nothing either way. */
+        VtcVettingVettersProfileV0_1VetterAcceptsDocumentation: components["schemas"]["VtcVettingVettersProfileV0_1VettingDocumentation"][];
+        /** @description Vetter-authored free text on when they are available to vet. Attributed to the vetter. */
+        VtcVettingVettersProfileV0_1VetterAvailability: string;
+        /** @description Vetter-authored free text on how to obtain a ticket from them, e.g. `Find me at the OpenVTC booth`. A hint, not an address a request can be sent to: vetting/request still needs a ticket or an introduction the vetter accepts. */
+        VtcVettingVettersProfileV0_1VetterContactHint: string;
+        /** @description The name the vetter chooses to be listed under. Self-asserted and unverified: it is not the name on any document, and a client MUST attribute it to the vetter. */
+        VtcVettingVettersProfileV0_1VetterDisplayName: string;
+        /** @description An event the vetter will attend and vet at. `endDate` is on or after `startDate` and no more than 31 days after it; JSON Schema cannot compare two members, so the community checks both and refuses a violation with `malformedRequest`. */
+        VtcVettingVettersProfileV0_1VetterEvent: {
+            endDate: components["schemas"]["VtcVettingVettersProfileV0_1CalendarDate"];
+            location?: components["schemas"]["VtcVettingVettersProfileV0_1VetterLocation"];
+            /** @description The event's name, e.g. `Linux Plumbers Conference 2026`. */
+            name: string;
+            startDate: components["schemas"]["VtcVettingVettersProfileV0_1CalendarDate"];
+            /**
+             * Format: uri
+             * @description OPTIONAL. The event's own https page.
+             */
+            url?: string;
+        };
+        /** @description Where a vetter can meet people, as coarse as the vetter chooses: a country, optionally a region, optionally a city. Never a street address. */
+        VtcVettingVettersProfileV0_1VetterLocation: {
+            city?: components["schemas"]["VtcVettingVettersProfileV0_1PlaceName"];
+            country: components["schemas"]["VtcVettingVettersProfileV0_1CountryCode"];
+            region?: components["schemas"]["VtcVettingVettersProfileV0_1PlaceName"];
+        };
+        /** @description The methods the vetter offers, from `inPerson`, `video`, `priorAcquaintance`. */
+        VtcVettingVettersProfileV0_1VetterMethods: components["schemas"]["VtcVettingVettersProfileV0_1VettingMethod"][];
+        /** @description A class of documentation, named in lowerCamelCase. Open rather than enumerated, because what documentation a vetter accepts is each vetter's own choice. Well-known values: `passport`, `nationalId`, `driverLicence`, and `none` — the vetter will attest without a document, which is the `priorAcquaintance` case. Only the class ever travels — never a document number, an image, an issuing authority or an expiry date. `none` states a policy (what a vetter accepts); a record of what was relied on expresses 'no document' as an empty list instead. */
+        VtcVettingVettersProfileV0_1VettingDocumentation: string;
+        /**
+         * @description How the vetter established that the person they checked is the person controlling the applicant's DID. `inPerson` — both people were physically together. `video` — a live, two-way video call. `priorAcquaintance` — the vetter has known or worked with this person over a period, and attests from that knowledge rather than from a document. A method is a description of what happened, not an assurance level: which methods count, and how many of each, is community policy.
+         * @enum {string}
+         */
+        VtcVettingVettersProfileV0_1VettingMethod: "inPerson" | "video" | "priorAcquaintance";
+        /** @description Vendor-namespaced extension object per SPEC.md §4.5.1. Each immediate key MUST be a reverse-DNS namespace; structure under each namespace is opaque to the framework. */
+        VtcVettingVettersResendV0_1Ext: {
+            [key: string]: unknown;
+        };
+        /** @description The credential the community delivered again. */
+        VtcVettingVettersResendV0_1Response: {
+            /** @description The `id` of the vetter role credential delivered — the same `credentialId` vtc/vetting/vetters/grant returned. */
+            credentialId: string;
+            /**
+             * Format: date-time
+             * @description That credential's `validUntil`.
+             */
+            validUntil: string;
+        };
         /**
          * @description Wire shape returned by `whoami`. Minimal: enough for the admin
          *     SPA's nav header to show "Signed in as …" with a role badge,
@@ -6595,7 +6696,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CommunityBranding"];
+                    "application/json": components["schemas"]["VtcJoinRequestsManifestV0_2CommunityBranding"];
                 };
             };
             /** @description Missing or invalid bearer token */
@@ -6616,7 +6717,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["CommunityBranding"];
+                "application/json": components["schemas"]["VtcJoinRequestsManifestV0_2CommunityBranding"];
             };
         };
         responses: {
@@ -6626,7 +6727,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CommunityBranding"];
+                    "application/json": components["schemas"]["VtcJoinRequestsManifestV0_2CommunityBranding"];
                 };
             };
             /** @description A member breaks its bounds */
@@ -7355,7 +7456,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["JoinRequestManifestResponseBody"];
+                    "application/json": components["schemas"]["VtcJoinRequestsManifestV0_2Response"];
                 };
             };
             /** @description Missing or invalid bearer token */
@@ -9419,7 +9520,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["VetterGrantBody"];
+                "application/json": components["schemas"]["VtcVettingVettersGrantV0_1Payload"];
             };
         };
         responses: {
@@ -9429,7 +9530,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["VetterGrantResponseBody"];
+                    "application/json": components["schemas"]["VtcVettingVettersGrantV0_1Response"];
                 };
             };
             /** @description Vetter role granted */
@@ -9438,7 +9539,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["VetterGrantResponseBody"];
+                    "application/json": components["schemas"]["VtcVettingVettersGrantV0_1Response"];
                 };
             };
             /** @description Malformed body, or the member is not a current member */
@@ -9473,7 +9574,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["VetterListBody"];
+                "application/json": components["schemas"]["VtcVettingVettersListV0_1Payload"];
             };
         };
         responses: {
@@ -9483,7 +9584,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["VetterListResponseBody"];
+                    "application/json": components["schemas"]["VtcVettingVettersListV0_1Response"];
                 };
             };
             /** @description A filter breaks its bounds, or the cursor was issued for other filters */
@@ -9527,7 +9628,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["VetterResendResponseBody"];
+                    "application/json": components["schemas"]["VtcVettingVettersResendV0_1Response"];
                 };
             };
             /** @description Missing or invalid bearer token */

--- a/vtc-service/admin-ui/src/plugins/vetting/RequirementsPanel.tsx
+++ b/vtc-service/admin-ui/src/plugins/vetting/RequirementsPanel.tsx
@@ -55,12 +55,8 @@ function CriterionCard({ criterion }: { criterion: ManifestCriterion }) {
   const titleId = `criterion-${criterion.id}`;
   const hasVetting = criterion.vetting !== undefined && criterion.vetting !== null;
   const problems = hasVetting ? validateRequirements(criterion.vetting) : [];
-  const requirements =
-    hasVetting && problems.length === 0
-      ? // The OpenAPI document types `vetting` as an opaque object; the
-        // validator above is what establishes this shape.
-        (criterion.vetting as unknown as VettingRequirements)
-      : null;
+  const requirements: VettingRequirements | null =
+    hasVetting && problems.length === 0 ? (criterion.vetting ?? null) : null;
 
   return (
     <section className="card" aria-labelledby={titleId}>

--- a/vtc-service/admin-ui/src/plugins/vetting/api.ts
+++ b/vtc-service/admin-ui/src/plugins/vetting/api.ts
@@ -186,8 +186,7 @@ export type { JoinManifest, ManifestCriterion };
 /**
  * `join-requests/manifest/0.2` as applicants receive it — each criterion with
  * its vetting requirements and `requirementsDigest` — from the admin route that
- * answers under the same task. A criterion's `vetting` is an opaque object in
- * the OpenAPI document; `validateRequirements` reads it.
+ * answers under the same task. The shape is the manifest specification's own.
  */
 export const fetchManifest = (): Promise<JoinManifest> =>
   getJson<JoinManifest>("/v1/join-requests/manifest", {

--- a/vtc-service/src/community/branding.rs
+++ b/vtc-service/src/community/branding.rs
@@ -3,17 +3,30 @@
 //!
 //! One row in the `community` keyspace at [`BRANDING_STORAGE_KEY`]. Published
 //! as `branding` on `join-requests/manifest/0.2`, and managed by an admin with
-//! `GET`/`PUT /v1/community/branding`. The shape is
-//! [`vta_sdk::protocols::join_requests::CommunityBranding`]; every member is
+//! `GET`/`PUT /v1/community/branding`. The shape is the manifest's own
+//! [`CommunityBranding`], generated from `vtc/join-requests/manifest/0.2`: what
+//! an admin stores is exactly what the manifest publishes. Every member is
 //! optional, and a community that has set none publishes no `branding` at all.
 
-use vta_sdk::protocols::join_requests::CommunityBranding;
+use vta_sdk::protocols::join_requests::manifest::v0_2::{
+    CommunityBranding, CommunityBrandingAccentColor,
+};
+use vta_sdk::protocols::vetting::CheckShape;
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
 /// Storage key in the `community` keyspace. Beside
 /// [`super::PROFILE_STORAGE_KEY`], and backed up with it.
 pub const BRANDING_STORAGE_KEY: &[u8] = b"community/branding";
+
+/// Nothing set: a community with this branding publishes none.
+#[must_use]
+pub fn is_empty(branding: &CommunityBranding) -> bool {
+    branding.display_name.is_none()
+        && branding.accent_color.is_none()
+        && branding.logo_url.is_none()
+        && branding.ext.is_none()
+}
 
 /// The stored branding, or the empty branding when none has been set.
 pub async fn load_branding(ks: &KeyspaceHandle) -> Result<CommunityBranding, AppError> {
@@ -24,10 +37,10 @@ pub async fn load_branding(ks: &KeyspaceHandle) -> Result<CommunityBranding, App
     }
 }
 
-/// Replace the branding, and return what was stored. Checks the bounds first,
-/// and writes `accentColor` in lower case, as the manifest specification asks
-/// (the colour is compared case-insensitively). An empty branding removes the
-/// row, so the manifest publishes none.
+/// Replace the branding, and return what was stored. Checks it against the
+/// manifest schema first, and writes `accentColor` in lower case, as the
+/// manifest specification asks (the colour is compared case-insensitively). An
+/// empty branding removes the row, so the manifest publishes none.
 pub async fn store_branding(
     ks: &KeyspaceHandle,
     branding: &CommunityBranding,
@@ -36,8 +49,12 @@ pub async fn store_branding(
         .check_shape()
         .map_err(|e| AppError::Validation(e.to_string()))?;
     let mut stored = branding.clone();
-    stored.accent_color = stored.accent_color.map(|c| c.to_ascii_lowercase());
-    if stored.is_empty() {
+    stored.accent_color = stored
+        .accent_color
+        .map(|c| CommunityBrandingAccentColor::try_from(c.to_ascii_lowercase()))
+        .transpose()
+        .map_err(|e| AppError::Validation(format!("accentColor: {e}")))?;
+    if is_empty(&stored) {
         ks.remove(BRANDING_STORAGE_KEY.to_vec()).await?;
         return Ok(stored);
     }
@@ -59,7 +76,9 @@ pub fn fields_changed(before: &CommunityBranding, after: &CommunityBranding) -> 
     if before.logo_url != after.logo_url {
         changed.push("logoUrl".to_string());
     }
-    if before.ext != after.ext {
+    // `ext` is an open map with no equality of its own; compare what it
+    // serialises to.
+    if serde_json::to_value(&before.ext).ok() != serde_json::to_value(&after.ext).ok() {
         changed.push("ext".to_string());
     }
     changed
@@ -68,6 +87,7 @@ pub fn fields_changed(before: &CommunityBranding, after: &CommunityBranding) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::{Value, json};
     use vti_common::config::StoreConfig;
     use vti_common::store::Store;
 
@@ -81,21 +101,30 @@ mod tests {
         (dir, store, ks)
     }
 
-    fn branded() -> CommunityBranding {
-        CommunityBranding {
-            display_name: Some("Linux Kernel".into()),
-            accent_color: Some("#1a2b3c".into()),
-            logo_url: Some("https://kernel.example.org/logo.svg".into()),
-            ext: None,
-        }
+    fn branded_json() -> Value {
+        json!({
+            "displayName": "Linux Kernel",
+            "accentColor": "#1a2b3c",
+            "logoUrl": "https://kernel.example.org/logo.svg"
+        })
+    }
+
+    fn branding(value: Value) -> CommunityBranding {
+        serde_json::from_value(value).unwrap()
+    }
+
+    fn wire(branding: &CommunityBranding) -> Value {
+        serde_json::to_value(branding).unwrap()
     }
 
     #[tokio::test]
     async fn branding_round_trips_and_clearing_it_removes_the_row() {
         let (_d, _s, ks) = ks().await;
-        assert!(load_branding(&ks).await.unwrap().is_empty());
-        store_branding(&ks, &branded()).await.unwrap();
-        assert_eq!(load_branding(&ks).await.unwrap(), branded());
+        assert!(is_empty(&load_branding(&ks).await.unwrap()));
+        store_branding(&ks, &branding(branded_json()))
+            .await
+            .unwrap();
+        assert_eq!(wire(&load_branding(&ks).await.unwrap()), branded_json());
         store_branding(&ks, &CommunityBranding::default())
             .await
             .unwrap();
@@ -105,59 +134,51 @@ mod tests {
     #[tokio::test]
     async fn the_accent_color_is_stored_in_lower_case() {
         let (_d, _s, ks) = ks().await;
-        let stored = store_branding(
-            &ks,
-            &CommunityBranding {
-                accent_color: Some("#1A2B3C".into()),
-                ..branded()
-            },
-        )
-        .await
-        .unwrap();
-        assert_eq!(stored.accent_color.as_deref(), Some("#1a2b3c"));
-        assert_eq!(load_branding(&ks).await.unwrap(), branded());
+        let mut upper = branded_json();
+        upper["accentColor"] = json!("#1A2B3C");
+        let stored = store_branding(&ks, &branding(upper)).await.unwrap();
+        assert_eq!(
+            stored.accent_color.as_deref().map(String::as_str),
+            Some("#1a2b3c")
+        );
+        assert_eq!(wire(&load_branding(&ks).await.unwrap()), branded_json());
     }
 
+    /// Refused on the way in by the generated member types, or by the
+    /// manifest schema when stored — never stored either way.
     #[tokio::test]
     async fn out_of_bounds_branding_is_refused_and_not_stored() {
         let (_d, _s, ks) = ks().await;
-        for bad in [
-            CommunityBranding {
-                accent_color: Some("red".into()),
-                ..branded()
-            },
-            CommunityBranding {
-                accent_color: Some("#12345g".into()),
-                ..branded()
-            },
-            CommunityBranding {
-                logo_url: Some("http://kernel.example.org/logo.svg".into()),
-                ..branded()
-            },
-            CommunityBranding {
-                display_name: Some("x".repeat(129)),
-                ..branded()
-            },
-            CommunityBranding {
-                display_name: Some(String::new()),
-                ..branded()
-            },
+        for (member, value) in [
+            ("accentColor", json!("red")),
+            ("accentColor", json!("#12345g")),
+            ("logoUrl", json!("http://kernel.example.org/logo.svg")),
+            ("displayName", json!("x".repeat(129))),
+            ("displayName", json!("")),
+            ("tagline", json!("x")),
         ] {
-            assert!(matches!(
-                store_branding(&ks, &bad).await,
-                Err(AppError::Validation(_))
-            ));
+            let mut bad = branded_json();
+            bad[member] = value;
+            if let Ok(parsed) = serde_json::from_value::<CommunityBranding>(bad) {
+                assert!(
+                    matches!(
+                        store_branding(&ks, &parsed).await,
+                        Err(AppError::Validation(_))
+                    ),
+                    "{member}"
+                );
+            }
         }
-        assert!(load_branding(&ks).await.unwrap().is_empty());
+        assert!(is_empty(&load_branding(&ks).await.unwrap()));
     }
 
     #[test]
     fn changed_fields_are_named_as_on_the_wire() {
-        let mut after = branded();
-        after.accent_color = Some("#000000".into());
-        after.ext = Some(serde_json::json!({ "x": 1 }));
+        let mut after = branded_json();
+        after["accentColor"] = json!("#000000");
+        after["ext"] = json!({ "org.example.console": { "theme": "dark" } });
         assert_eq!(
-            fields_changed(&branded(), &after),
+            fields_changed(&branding(branded_json()), &branding(after)),
             vec!["accentColor", "ext"]
         );
     }

--- a/vtc-service/src/routes/community/branding.rs
+++ b/vtc-service/src/routes/community/branding.rs
@@ -3,13 +3,16 @@
 //! `join-requests/manifest/0.2`.
 //!
 //! Admin REST with no Trust Task of its own; mounted without a binding. The
-//! body is [`CommunityBranding`], replaced whole.
+//! body is the manifest 0.2 `CommunityBranding` definition
+//! ([`JoinManifest02CommunityBranding`]), replaced whole — what the admin stores
+//! is what the manifest publishes.
 
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use tracing::info;
-use vta_sdk::protocols::join_requests::CommunityBranding;
+use vta_sdk::openapi::JoinManifest02CommunityBranding;
+use vta_sdk::protocols::vetting::read_branding;
 use vti_common::audit::{AuditEvent, CommunityBrandingUpdatedData};
 use vti_common::auth::{AdminAuth, AuthClaims};
 use vti_common::error::AppError;
@@ -23,15 +26,15 @@ use crate::server::AppState;
     operation_id = "communityBrandingShow", tag = "community",
     security(("bearer_jwt" = [])),
     responses(
-        (status = 200, description = "The community's branding", body = CommunityBranding),
+        (status = 200, description = "The community's branding", body = JoinManifest02CommunityBranding),
         (status = 401, description = "Missing or invalid bearer token"),
     ),
 )]
 pub async fn get_branding(
     _auth: AuthClaims,
     State(state): State<AppState>,
-) -> Result<Json<CommunityBranding>, AppError> {
-    Ok(Json(load_branding(&state.community_ks).await?))
+) -> Result<Json<JoinManifest02CommunityBranding>, AppError> {
+    Ok(Json(load_branding(&state.community_ks).await?.into()))
 }
 
 /// Replace the community's branding. An empty body clears it.
@@ -39,9 +42,9 @@ pub async fn get_branding(
     put, path = "/community/branding",
     operation_id = "communityBrandingUpdate", tag = "community",
     security(("bearer_jwt" = [])),
-    request_body = CommunityBranding,
+    request_body = JoinManifest02CommunityBranding,
     responses(
-        (status = 200, description = "The stored branding", body = CommunityBranding),
+        (status = 200, description = "The stored branding", body = JoinManifest02CommunityBranding),
         (status = 400, description = "A member breaks its bounds"),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
@@ -51,8 +54,11 @@ pub async fn get_branding(
 pub async fn put_branding(
     admin: AdminAuth,
     State(state): State<AppState>,
-    Json(body): Json<CommunityBranding>,
-) -> Result<Json<CommunityBranding>, AppError> {
+    // Read as JSON, then checked against the manifest schema before parsing:
+    // the body is the manifest's `CommunityBranding`, as documented above.
+    Json(body): Json<serde_json::Value>,
+) -> Result<Json<JoinManifest02CommunityBranding>, AppError> {
+    let body = read_branding(&body).map_err(|e| AppError::Validation(e.to_string()))?;
     // Fail closed, as the profile route does: a change that cannot be audited
     // is not made.
     let writer = state
@@ -77,5 +83,5 @@ pub async fn put_branding(
             .await?;
         info!(fields_changed = ?changed, "community branding updated");
     }
-    Ok(Json(stored))
+    Ok(Json(stored.into()))
 }

--- a/vtc-service/src/routes/join_requests/manifest.rs
+++ b/vtc-service/src/routes/join_requests/manifest.rs
@@ -31,6 +31,7 @@ use serde_json::{Map, Value};
 
 use vta_sdk::openapi::{JoinManifest01Response, JoinManifest02Response};
 use vta_sdk::protocols::join_requests::manifest::{v0_1, v0_2};
+use vta_sdk::protocols::vetting::CheckShape;
 use vta_sdk::vetting::requirements::requirements_digest;
 use vti_common::auth::AdminAuth;
 use vti_common::error::AppError;
@@ -137,12 +138,24 @@ pub fn response_v0_1(
     .map_err(|e| AppError::Internal(format!("manifest 0.1: {e}")))
 }
 
-/// The 0.2 answer over `stored` criteria.
+/// The 0.2 answer over `stored` criteria and `branding`.
+///
+/// Branding the manifest cannot carry — a `logoUrl` that is not an absolute
+/// https URI among it — is not emitted. Storing branding refuses it first
+/// ([`crate::community::branding::store_branding`]), so only a row written
+/// before that check can reach here, and it is the community's fault.
 pub fn response_v0_2(
     community_did: String,
     stored: Vec<AcceptsCriterion>,
     branding: Option<v0_2::CommunityBranding>,
 ) -> Result<v0_2::Response, AppError> {
+    if let Some(branding) = &branding {
+        branding.check_shape().map_err(|e| {
+            AppError::Internal(format!(
+                "the stored branding does not project onto the manifest: {e}"
+            ))
+        })?;
+    }
     let criteria = stored
         .into_iter()
         .map(manifest_criterion)
@@ -331,5 +344,27 @@ mod tests {
             manifest_criterion(long_description),
             Err(AppError::Validation(_))
         ));
+    }
+
+    #[test]
+    fn branding_the_manifest_cannot_carry_is_not_emitted() {
+        let answer = |logo: &str| {
+            let branding: v0_2::CommunityBranding =
+                serde_json::from_value(json!({ "displayName": "Kernel", "logoUrl": logo }))
+                    .unwrap();
+            response_v0_2(
+                "did:web:vtc.example".into(),
+                vec![stored(None)],
+                Some(branding),
+            )
+        };
+        assert!(answer("https://kernel.example/logo.svg").is_ok());
+        for bad in [
+            "https://kernel.example/my logo.svg",
+            "https://kernel.example/logo\u{7}.svg",
+            "http://kernel.example/logo.svg",
+        ] {
+            assert!(matches!(answer(bad), Err(AppError::Internal(_))), "{bad:?}");
+        }
     }
 }

--- a/vtc-service/src/routes/join_requests/manifest.rs
+++ b/vtc-service/src/routes/join_requests/manifest.rs
@@ -31,7 +31,7 @@ use serde_json::{Map, Value};
 
 use vta_sdk::openapi::{JoinManifest01Response, JoinManifest02Response};
 use vta_sdk::protocols::join_requests::manifest::{v0_1, v0_2};
-use vta_sdk::protocols::vetting::CheckShape;
+use vta_sdk::protocols::vetting::{CheckShape, read_branding};
 use vta_sdk::vetting::requirements::requirements_digest;
 use vti_common::auth::AdminAuth;
 use vti_common::error::AppError;
@@ -141,21 +141,29 @@ pub fn response_v0_1(
 /// The 0.2 answer over `stored` criteria and `branding`.
 ///
 /// Branding the manifest cannot carry — a `logoUrl` that is not an absolute
-/// https URI among it — is not emitted. Storing branding refuses it first
-/// ([`crate::community::branding::store_branding`]), so only a row written
-/// before that check can reach here, and it is the community's fault.
+/// https URI among it — is left out, and the manifest is served without it.
+/// Branding is presentation only, and the manifest is what every applicant
+/// needs to join, so a bad logo address must not stop joins. Storing branding
+/// refuses such a value first ([`crate::community::branding::store_branding`]),
+/// so only a row written before that check can reach here; a warning names the
+/// members at fault, never their values, which may be hostile.
 pub fn response_v0_2(
     community_did: String,
     stored: Vec<AcceptsCriterion>,
     branding: Option<v0_2::CommunityBranding>,
 ) -> Result<v0_2::Response, AppError> {
-    if let Some(branding) = &branding {
-        branding.check_shape().map_err(|e| {
-            AppError::Internal(format!(
-                "the stored branding does not project onto the manifest: {e}"
-            ))
-        })?;
-    }
+    let branding = branding.filter(|branding| {
+        if branding.check_shape().is_ok() {
+            return true;
+        }
+        let members = invalid_branding_members(branding);
+        tracing::warn!(
+            members = %if members.is_empty() { "branding".to_string() } else { members.join(", ") },
+            "the stored community branding breaks the join manifest's CommunityBranding \
+             definition; serving manifest 0.2 without branding until an admin replaces it"
+        );
+        false
+    });
     let criteria = stored
         .into_iter()
         .map(manifest_criterion)
@@ -168,6 +176,23 @@ pub fn response_v0_2(
             .branding(branding),
     )
     .map_err(|e| AppError::Internal(format!("manifest 0.2: {e}")))
+}
+
+/// The top-level members of `branding` that fail the manifest's
+/// `CommunityBranding` definition on their own. Names only: a value is what an
+/// admin typed, and a log is no place to repeat a hostile one.
+fn invalid_branding_members(branding: &v0_2::CommunityBranding) -> Vec<String> {
+    let Ok(Value::Object(members)) = serde_json::to_value(branding) else {
+        return Vec::new();
+    };
+    members
+        .into_iter()
+        .filter(|(name, value)| {
+            let alone = Value::Object(Map::from_iter([(name.clone(), value.clone())]));
+            read_branding(&alone).is_err()
+        })
+        .map(|(name, _)| name)
+        .collect()
 }
 
 /// A stored criterion that does not project onto the manifest is the
@@ -346,25 +371,42 @@ mod tests {
         ));
     }
 
+    fn branding(logo: &str) -> v0_2::CommunityBranding {
+        serde_json::from_value(json!({ "displayName": "Kernel", "logoUrl": logo })).unwrap()
+    }
+
     #[test]
-    fn branding_the_manifest_cannot_carry_is_not_emitted() {
+    fn branding_the_manifest_cannot_carry_is_omitted_and_the_manifest_still_served() {
         let answer = |logo: &str| {
-            let branding: v0_2::CommunityBranding =
-                serde_json::from_value(json!({ "displayName": "Kernel", "logoUrl": logo }))
-                    .unwrap();
             response_v0_2(
                 "did:web:vtc.example".into(),
                 vec![stored(None)],
-                Some(branding),
+                Some(branding(logo)),
             )
+            .expect("branding must never fail the manifest an applicant joins by")
         };
-        assert!(answer("https://kernel.example/logo.svg").is_ok());
+        let good = answer("https://kernel.example/logo.svg");
+        assert_eq!(
+            good.branding.and_then(|b| b.logo_url),
+            Some("https://kernel.example/logo.svg".to_string())
+        );
         for bad in [
             "https://kernel.example/my logo.svg",
             "https://kernel.example/logo\u{7}.svg",
             "http://kernel.example/logo.svg",
         ] {
-            assert!(matches!(answer(bad), Err(AppError::Internal(_))), "{bad:?}");
+            let manifest = answer(bad);
+            assert!(manifest.branding.is_none(), "{bad:?}");
+            assert_eq!(manifest.criteria.len(), 1, "{bad:?}");
         }
+    }
+
+    #[test]
+    fn the_warning_names_the_member_at_fault_not_its_value() {
+        assert_eq!(
+            invalid_branding_members(&branding("https://kernel.example/my logo.svg")),
+            vec!["logoUrl".to_string()]
+        );
+        assert!(invalid_branding_members(&branding("https://kernel.example/logo.svg")).is_empty());
     }
 }

--- a/vtc-service/src/routes/join_requests/manifest.rs
+++ b/vtc-service/src/routes/join_requests/manifest.rs
@@ -1,6 +1,6 @@
 //! Pre-submit discovery — the join manifest (`vtc/join-requests/manifest/0.1`
-//! and `/0.2`) — plus a shared `manifest_inner` the Trust Task dispatcher and
-//! the DIDComm handler call into.
+//! and `/0.2`) — plus the shared reads the Trust Task dispatcher and the
+//! DIDComm handler call into.
 //!
 //! Returns the community's registered Accepts criteria — each a named
 //! DCQL Presentation Definition — plus this VTC's DID, so a prospective
@@ -8,26 +8,34 @@
 //! stateless, unauthenticated public read: no thread, no challenge, no
 //! audit.
 //!
+//! Both answers are the generated `manifest::v0_1::Response` and
+//! `manifest::v0_2::Response`; this module only projects stored criteria onto
+//! them.
+//!
 //! ## 0.1 and 0.2
 //!
 //! 0.2 adds, per criterion, the peer-vetting requirements the community
-//! registered and a `requirementsDigest` over the criterion. An applicant
-//! records the digest when it starts gathering statements, so a change to the
-//! requirements mid-application is detectable rather than a surprise at submit
-//! (OpenVTC `docs/design/vetting-process.md` §6.3).
+//! registered and a `requirementsDigest` over the criterion, and the
+//! community's branding. An applicant records the digest when it starts
+//! gathering statements, so a change to the requirements mid-application is
+//! detectable rather than a surprise at submit (OpenVTC
+//! `docs/design/vetting-process.md` §6.3).
 //!
-//! A 0.1 answer carries neither member: the version the applicant asked for
-//! decides the shape, and a 0.1 reader is not handed members its version does
-//! not define.
+//! A 0.1 answer carries none of those members: the version the applicant asked
+//! for decides the shape, and a 0.1 reader is not handed members its version
+//! does not define.
 
 use axum::Json;
 use axum::extract::State;
+use serde_json::{Map, Value};
 
-use vta_sdk::protocols::join_requests::{JoinRequestManifestResponseBody, ManifestCriterion};
+use vta_sdk::openapi::{JoinManifest01Response, JoinManifest02Response};
+use vta_sdk::protocols::join_requests::manifest::{v0_1, v0_2};
 use vta_sdk::vetting::requirements::requirements_digest;
 use vti_common::auth::AdminAuth;
 use vti_common::error::AppError;
 
+use crate::community::branding;
 use crate::schemas::accepts::{AcceptsCriterion, list_accepts};
 use crate::server::AppState;
 
@@ -44,7 +52,7 @@ use crate::server::AppState;
     operation_id = "joinRequestManifestShow", tag = "join-requests",
     security(("bearer_jwt" = [])),
     responses(
-        (status = 200, description = "The join manifest (0.2): each criterion with its vetting requirements and requirementsDigest, and the branding", body = JoinRequestManifestResponseBody),
+        (status = 200, description = "The join manifest (0.2): each criterion with its vetting requirements and requirementsDigest, and the branding", body = JoinManifest02Response),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
     ),
@@ -52,8 +60,8 @@ use crate::server::AppState;
 pub async fn admin_manifest(
     _admin: AdminAuth,
     State(state): State<AppState>,
-) -> Result<Json<JoinRequestManifestResponseBody>, AppError> {
-    Ok(Json(manifest_inner(&state, ManifestVersion::V0_2).await?))
+) -> Result<Json<JoinManifest02Response>, AppError> {
+    Ok(Json(manifest_v0_2(&state).await?.into()))
 }
 
 /// Which manifest version a caller asked for.
@@ -62,7 +70,7 @@ pub enum ManifestVersion {
     /// `vtc/join-requests/manifest/0.1` — criteria only.
     V0_1,
     /// `vtc/join-requests/manifest/0.2` — criteria with their vetting
-    /// requirements and a `requirementsDigest`.
+    /// requirements and a `requirementsDigest`, and the branding.
     V0_2,
 }
 
@@ -71,75 +79,163 @@ pub enum ManifestVersion {
 #[utoipa::path(
     get, path = "/join-requests/manifest", tag = "join-requests",
     responses(
-        (status = 200, description = "Community join evidence requirements", body = JoinRequestManifestResponseBody),
+        (status = 200, description = "Community join evidence requirements", body = JoinManifest01Response),
     ),
 )]
 pub async fn manifest(
     State(state): State<AppState>,
-) -> Result<Json<JoinRequestManifestResponseBody>, AppError> {
-    Ok(Json(manifest_inner(&state, ManifestVersion::V0_1).await?))
+) -> Result<Json<JoinManifest01Response>, AppError> {
+    Ok(Json(manifest_v0_1(&state).await?.into()))
 }
 
-/// Shared discovery read for REST + DIDComm: the community's join
-/// evidence requirements, in the shape `version` defines.
-pub async fn manifest_inner(
-    state: &AppState,
-    version: ManifestVersion,
-) -> Result<JoinRequestManifestResponseBody, AppError> {
-    let community_did = state
+async fn community_did(state: &AppState) -> Result<String, AppError> {
+    state
         .config
         .read()
         .await
         .vtc_did
         .clone()
         .filter(|d| !d.is_empty())
-        .ok_or_else(|| AppError::Internal("VTC DID not configured".into()))?;
-
-    let criteria = list_accepts(&state.schemas_ks)
-        .await?
-        .into_iter()
-        .map(|c| manifest_criterion(c, version))
-        .collect::<Result<Vec<_>, _>>()?;
-
-    // 0.2 only, and only when the community set some: 0.1 defines no branding.
-    let branding = match version {
-        ManifestVersion::V0_1 => None,
-        ManifestVersion::V0_2 => Some(crate::community::load_branding(&state.community_ks).await?)
-            .filter(|b| !b.is_empty()),
-    };
-
-    Ok(JoinRequestManifestResponseBody {
-        community_did,
-        criteria,
-        branding,
-    })
+        .ok_or_else(|| AppError::Internal("VTC DID not configured".into()))
 }
 
-/// Project a stored criterion into the manifest shape `version` defines.
+/// The community's `vtc/join-requests/manifest/0.1` answer.
+pub async fn manifest_v0_1(state: &AppState) -> Result<v0_1::Response, AppError> {
+    response_v0_1(
+        community_did(state).await?,
+        list_accepts(&state.schemas_ks).await?,
+    )
+}
+
+/// The community's `vtc/join-requests/manifest/0.2` answer. Branding only when
+/// the community has set some.
+pub async fn manifest_v0_2(state: &AppState) -> Result<v0_2::Response, AppError> {
+    let branding = Some(branding::load_branding(&state.community_ks).await?)
+        .filter(|b| !branding::is_empty(b));
+    response_v0_2(
+        community_did(state).await?,
+        list_accepts(&state.schemas_ks).await?,
+        branding,
+    )
+}
+
+/// The 0.1 answer over `stored` criteria.
+pub fn response_v0_1(
+    community_did: String,
+    stored: Vec<AcceptsCriterion>,
+) -> Result<v0_1::Response, AppError> {
+    let criteria = stored
+        .into_iter()
+        .map(criterion_v0_1)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(stored_fault)?;
+    v0_1::Response::try_from(
+        v0_1::Response::builder()
+            .community_did(community_did)
+            .criteria(criteria),
+    )
+    .map_err(|e| AppError::Internal(format!("manifest 0.1: {e}")))
+}
+
+/// The 0.2 answer over `stored` criteria.
+pub fn response_v0_2(
+    community_did: String,
+    stored: Vec<AcceptsCriterion>,
+    branding: Option<v0_2::CommunityBranding>,
+) -> Result<v0_2::Response, AppError> {
+    let criteria = stored
+        .into_iter()
+        .map(manifest_criterion)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(stored_fault)?;
+    v0_2::Response::try_from(
+        v0_2::Response::builder()
+            .community_did(community_did)
+            .criteria(criteria)
+            .branding(branding),
+    )
+    .map_err(|e| AppError::Internal(format!("manifest 0.2: {e}")))
+}
+
+/// A stored criterion that does not project onto the manifest is the
+/// community's fault, not the caller's. Registration refuses one
+/// ([`crate::schemas::accepts::store_accepts`]), so only a row written before
+/// that check can reach here.
+fn stored_fault(e: AppError) -> AppError {
+    AppError::Internal(format!(
+        "a stored accepts criterion does not project onto the manifest: {e}"
+    ))
+}
+
+/// Project a stored criterion onto `vtc/join-requests/manifest/0.1`.
 ///
-/// The 0.2 digest is computed over the criterion exactly as it is delivered,
-/// minus the digest member, so an applicant recomputes it from what it
-/// received with [`requirements_digest`] and gets the same value.
-pub fn manifest_criterion(
-    stored: AcceptsCriterion,
-    version: ManifestVersion,
-) -> Result<ManifestCriterion, AppError> {
-    let mut criterion = ManifestCriterion {
-        id: stored.id,
-        description: stored.description,
-        presentation_definition: stored.query,
-        vetting: None,
-        requirements_digest: None,
-    };
-    if version == ManifestVersion::V0_2 {
-        criterion.vetting = stored.vetting;
-        let delivered = serde_json::to_value(&criterion)
-            .map_err(|e| AppError::Internal(format!("manifest criterion encode: {e}")))?;
-        let digest = requirements_digest(&delivered)
-            .map_err(|e| AppError::Internal(format!("requirements digest: {e:?}")))?;
-        criterion.requirements_digest = Some(digest);
-    }
+/// # Errors
+///
+/// [`AppError::Validation`] naming the member the manifest schema refuses.
+pub fn criterion_v0_1(stored: AcceptsCriterion) -> Result<v0_1::ResponseCriteriaItem, AppError> {
+    let description = stored
+        .description
+        .map(v0_1::ResponseCriteriaItemDescription::try_from)
+        .transpose()
+        .map_err(|e| refused("description", e))?;
+    v0_1::ResponseCriteriaItem::try_from(
+        v0_1::ResponseCriteriaItem::builder()
+            .id(stored.id)
+            .description(description)
+            .presentation_definition(query_object(stored.query)?),
+    )
+    .map_err(|e| refused("criterion", e))
+}
+
+/// Project a stored criterion onto `vtc/join-requests/manifest/0.2`, with its
+/// `requirementsDigest`.
+///
+/// The digest is computed over the criterion exactly as it is delivered, minus
+/// the digest member, so an applicant recomputes it from what it received with
+/// [`requirements_digest`] and gets the same value.
+///
+/// # Errors
+///
+/// [`AppError::Validation`] naming the member the manifest schema refuses.
+pub fn manifest_criterion(stored: AcceptsCriterion) -> Result<v0_2::Criterion, AppError> {
+    let description = stored
+        .description
+        .map(v0_2::CriterionDescription::try_from)
+        .transpose()
+        .map_err(|e| refused("description", e))?;
+    let mut criterion = v0_2::Criterion::try_from(
+        v0_2::Criterion::builder()
+            .id(stored.id)
+            .description(description)
+            .presentation_definition(query_object(stored.query)?)
+            .vetting(stored.vetting),
+    )
+    .map_err(|e| refused("criterion", e))?;
+    let delivered = serde_json::to_value(&criterion)
+        .map_err(|e| AppError::Internal(format!("manifest criterion encode: {e}")))?;
+    let digest = requirements_digest(&delivered)
+        .map_err(|e| AppError::Internal(format!("requirements digest: {e}")))?;
+    criterion.requirements_digest = Some(
+        v0_2::DigestMultibase::try_from(digest)
+            .map_err(|e| AppError::Internal(format!("requirements digest: {e}")))?,
+    );
     Ok(criterion)
+}
+
+fn refused(member: &str, e: impl std::fmt::Display) -> AppError {
+    AppError::Validation(format!(
+        "the join manifest cannot carry this criterion's {member}: {e}"
+    ))
+}
+
+/// A criterion's `presentationDefinition` is a JSON object.
+fn query_object(query: Value) -> Result<Map<String, Value>, AppError> {
+    match query {
+        Value::Object(query) => Ok(query),
+        _ => Err(AppError::Validation(
+            "an accepts criterion's query must be a JSON object".into(),
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -173,15 +269,16 @@ mod tests {
 
     #[test]
     fn a_0_1_answer_carries_no_vetting_members() {
-        let c = manifest_criterion(stored(Some(requirements(2))), ManifestVersion::V0_1).unwrap();
+        let c = criterion_v0_1(stored(Some(requirements(2)))).unwrap();
         let v = serde_json::to_value(&c).unwrap();
         assert!(v.get("vetting").is_none());
         assert!(v.get("requirementsDigest").is_none());
+        assert_eq!(v["id"], "kernel-developer");
     }
 
     #[test]
     fn a_0_2_digest_recomputes_from_what_the_applicant_receives() {
-        let c = manifest_criterion(stored(Some(requirements(2))), ManifestVersion::V0_2).unwrap();
+        let c = manifest_criterion(stored(Some(requirements(2)))).unwrap();
         let received = serde_json::to_value(&c).unwrap();
         assert_eq!(received["vetting"]["minStatements"], 2);
         assert_eq!(
@@ -193,16 +290,46 @@ mod tests {
 
     #[test]
     fn changing_the_requirements_changes_the_digest() {
-        let two = manifest_criterion(stored(Some(requirements(2))), ManifestVersion::V0_2).unwrap();
-        let three =
-            manifest_criterion(stored(Some(requirements(3))), ManifestVersion::V0_2).unwrap();
-        assert_ne!(two.requirements_digest, three.requirements_digest);
+        let digest = |min| {
+            manifest_criterion(stored(Some(requirements(min))))
+                .unwrap()
+                .requirements_digest
+                .map(String::from)
+        };
+        assert_ne!(digest(2), digest(3));
     }
 
     #[test]
     fn a_criterion_without_vetting_still_gets_a_digest_under_0_2() {
-        let c = manifest_criterion(stored(None), ManifestVersion::V0_2).unwrap();
+        let c = manifest_criterion(stored(None)).unwrap();
         assert!(c.vetting.is_none());
         assert!(c.requirements_digest.is_some());
+    }
+
+    #[test]
+    fn a_criterion_the_manifest_cannot_carry_is_refused() {
+        // 0.2 bounds a criterion id at 128 characters; 0.1 set no upper bound.
+        // Registration projects onto 0.2, so the stricter one decides.
+        let mut long_id = stored(None);
+        long_id.id = "x".repeat(129);
+        assert!(matches!(
+            manifest_criterion(long_id.clone()),
+            Err(AppError::Validation(_))
+        ));
+        assert!(criterion_v0_1(long_id).is_ok());
+
+        let mut not_an_object = stored(None);
+        not_an_object.query = json!(["credentials"]);
+        assert!(matches!(
+            manifest_criterion(not_an_object),
+            Err(AppError::Validation(_))
+        ));
+
+        let mut long_description = stored(None);
+        long_description.description = Some("x".repeat(1025));
+        assert!(matches!(
+            manifest_criterion(long_description),
+            Err(AppError::Validation(_))
+        ));
     }
 }

--- a/vtc-service/src/routes/schemas.rs
+++ b/vtc-service/src/routes/schemas.rs
@@ -204,7 +204,7 @@ pub struct RegisterAcceptsBody {
     /// Peer identity vetting this criterion requires, advertised in the join
     /// manifest (0.2). Its `statementType` must be a registered endorsement type.
     #[serde(default)]
-    #[schema(value_type = Option<Object>)]
+    #[schema(value_type = Option<vta_sdk::openapi::JoinManifest02VettingRequirements>)]
     pub vetting: Option<VettingRequirements>,
 }
 

--- a/vtc-service/src/routes/vetting.rs
+++ b/vtc-service/src/routes/vetting.rs
@@ -30,9 +30,12 @@ use axum::http::StatusCode;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use uuid::Uuid;
+use vta_sdk::openapi::{
+    VetterGrant01Payload, VetterGrant01Response, VetterList01Payload, VetterList01Response,
+    VetterResend01Response,
+};
 use vta_sdk::protocols::vetting::{
-    AutoGrantConfig, AutoGrantStatus, VetterGrantBody, VetterGrantListResponse,
-    VetterGrantResponseBody, VetterListBody, VetterListResponseBody, VetterResendResponseBody,
+    AutoGrantConfig, AutoGrantStatus, VetterGrantListResponse, read_checked,
 };
 use vti_common::auth::{AdminAuth, AuthClaims};
 use vti_common::error::AppError;
@@ -46,10 +49,10 @@ use crate::vetting::{auto_grant, revocation, vetters};
     post, path = "/vetting/vetters",
     operation_id = "vettingVetterGrant", tag = "vetting",
     security(("bearer_jwt" = [])),
-    request_body = VetterGrantBody,
+    request_body = VetterGrant01Payload,
     responses(
-        (status = 201, description = "Vetter role granted", body = VetterGrantResponseBody),
-        (status = 200, description = "The member already holds a live vetter grant, which is returned", body = VetterGrantResponseBody),
+        (status = 201, description = "Vetter role granted", body = VetterGrant01Response),
+        (status = 200, description = "The member already holds a live vetter grant, which is returned", body = VetterGrant01Response),
         (status = 400, description = "Malformed body, or the member is not a current member"),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not a community admin"),
@@ -58,15 +61,20 @@ use crate::vetting::{auto_grant, revocation, vetters};
 pub async fn grant_vetter(
     auth: AuthClaims,
     State(state): State<AppState>,
-    Json(body): Json<VetterGrantBody>,
-) -> Result<(StatusCode, Json<VetterGrantResponseBody>), AppError> {
+    // Read as JSON, then checked against the published schema before parsing:
+    // the body is `vtc/vetting/vetters/grant/0.1`'s payload, as documented above.
+    Json(body): Json<serde_json::Value>,
+) -> Result<(StatusCode, Json<VetterGrant01Response>), AppError> {
+    let body: VetterGrant01Payload = read_checked(&body)
+        .map(VetterGrant01Payload)
+        .map_err(|e| AppError::Validation(e.to_string()))?;
     let grant = vetters::grant(&state, &auth.did, &body).await?;
     let status = if grant.created() {
         StatusCode::CREATED
     } else {
         StatusCode::OK
     };
-    Ok((status, Json(grant.response)))
+    Ok((status, Json(grant.response.into())))
 }
 
 /// Every vetter grant, newest first.
@@ -96,7 +104,7 @@ pub async fn list_vetters(
     security(("bearer_jwt" = [])),
     params(("memberDid" = String, Path, description = "The vetter's member DID")),
     responses(
-        (status = 200, description = "The credential was handed to the transport for delivery", body = VetterResendResponseBody),
+        (status = 200, description = "The credential was handed to the transport for delivery", body = VetterResend01Response),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not a community admin"),
         (status = 404, description = "The member holds no live vetter grant whose credential the community kept"),
@@ -107,9 +115,11 @@ pub async fn resend_vetter(
     auth: AuthClaims,
     State(state): State<AppState>,
     Path(member_did): Path<String>,
-) -> Result<Json<VetterResendResponseBody>, AppError> {
+) -> Result<Json<VetterResend01Response>, AppError> {
     Ok(Json(
-        vetters::resend_as_admin(&state, &auth.did, &member_did).await?,
+        vetters::resend_as_admin(&state, &auth.did, &member_did)
+            .await?
+            .into(),
     ))
 }
 
@@ -122,9 +132,9 @@ pub async fn resend_vetter(
     post, path = "/vetting/vetters/list",
     operation_id = "vettingVetterListing", tag = "vetting",
     security(("bearer_jwt" = [])),
-    request_body = VetterListBody,
+    request_body = VetterList01Payload,
     responses(
-        (status = 200, description = "A page of listed vetters", body = VetterListResponseBody),
+        (status = 200, description = "A page of listed vetters", body = VetterList01Response),
         (status = 400, description = "A filter breaks its bounds, or the cursor was issued for other filters"),
         (status = 401, description = "Missing or invalid bearer token"),
         (status = 403, description = "Caller is not an admin"),
@@ -133,9 +143,16 @@ pub async fn resend_vetter(
 pub async fn list_listed_vetters(
     _admin: AdminAuth,
     State(state): State<AppState>,
-    Json(body): Json<VetterListBody>,
-) -> Result<Json<VetterListResponseBody>, AppError> {
-    Ok(Json(crate::vetting::profiles::list(&state, &body).await?))
+    // Read as JSON, then checked against the published schema before parsing:
+    // the body is `vtc/vetting/vetters/list/0.1`'s payload, as documented above.
+    Json(body): Json<serde_json::Value>,
+) -> Result<Json<VetterList01Response>, AppError> {
+    let body: VetterList01Payload = read_checked(&body)
+        .map(VetterList01Payload)
+        .map_err(|e| AppError::Validation(e.to_string()))?;
+    Ok(Json(
+        crate::vetting::profiles::list(&state, &body).await?.into(),
+    ))
 }
 
 /// The automatic vetter-grant configuration and the last sweep.
@@ -285,10 +302,7 @@ pub async fn list_revocations(
             },
             affected_join_requests: affected.iter().map(|(id, _)| *id).collect(),
             affected_members: members.into_iter().collect(),
-            reason: notice
-                .reason
-                .and_then(|r| serde_json::to_value(r).ok())
-                .and_then(|v| v.as_str().map(str::to_string)),
+            reason: notice.reason.map(|r| r.to_string()),
             issuer: notice.issuer,
             statement_id: notice.statement_id,
             statement_digest_multibase: notice.statement_digest_multibase,

--- a/vtc-service/src/schemas/accepts.rs
+++ b/vtc-service/src/schemas/accepts.rs
@@ -24,7 +24,7 @@ use affinidi_openid4vp::DcqlQuery;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use vta_sdk::protocols::vetting::VettingRequirements;
+use vta_sdk::protocols::vetting::{CheckShape, VettingRequirements};
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
 
@@ -43,7 +43,7 @@ fn key(id: &str) -> Vec<u8> {
 /// A named required-evidence criterion: a DCQL query over the schema-store
 /// registry that a ceremony runs to decide whether a holder's presented
 /// credentials satisfy the community's acceptance rules.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[derive(utoipa::ToSchema)]
 pub struct AcceptsCriterion {
@@ -57,12 +57,12 @@ pub struct AcceptsCriterion {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Peer identity vetting this criterion requires, advertised to applicants
-    /// in the join manifest (0.2). Every number in it is this community's
-    /// policy. Checked by [`VettingRequirements::validate`] when stored; the
-    /// admin route additionally requires its `statementType` to be a registered
-    /// endorsement type.
+    /// in the join manifest (0.2): the manifest's own `VettingRequirements`.
+    /// Every number in it is this community's policy. Checked against the
+    /// manifest schema when stored; the admin route additionally requires its
+    /// `statementType` to be a registered endorsement type.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<Object>)]
+    #[schema(value_type = Option<vta_sdk::openapi::JoinManifest02VettingRequirements>)]
     pub vetting: Option<VettingRequirements>,
     pub created_at: DateTime<Utc>,
     /// Admin DID that registered the criterion (audit correlation).
@@ -108,9 +108,10 @@ pub async fn validate_accepts_query(
 }
 
 /// Validate + store an Accepts criterion. The query is validated against the
-/// registry first, and any vetting requirements must be evaluable; a criterion
-/// with a malformed query, a dangling type reference or requirements no
-/// applicant could satisfy is **not** stored.
+/// registry first, any vetting requirements must be evaluable, and the
+/// criterion must be one the join manifest can publish; a criterion with a
+/// malformed query, a dangling type reference, requirements no applicant could
+/// satisfy, or a member the manifest schema refuses is **not** stored.
 pub async fn store_accepts(
     schemas_ks: &KeyspaceHandle,
     criterion: &AcceptsCriterion,
@@ -118,9 +119,10 @@ pub async fn store_accepts(
     validate_accepts_query(schemas_ks, &criterion.query).await?;
     if let Some(vetting) = &criterion.vetting {
         vetting
-            .validate()
-            .map_err(|e| AppError::Validation(e.to_string()))?;
+            .check_shape()
+            .map_err(|e| AppError::Validation(format!("vetting: {e}")))?;
     }
+    crate::routes::join_requests::manifest::manifest_criterion(criterion.clone())?;
     schemas_ks
         .insert(
             String::from_utf8(key(&criterion.id)).expect("ascii key"),
@@ -228,7 +230,10 @@ mod tests {
             .expect("valid criterion stores");
 
         let got = get_accepts(&ks, "join").await.unwrap().unwrap();
-        assert_eq!(got, c);
+        assert_eq!(
+            serde_json::to_value(&got).unwrap(),
+            serde_json::to_value(&c).unwrap()
+        );
         assert_eq!(list_accepts(&ks).await.unwrap().len(), 1);
 
         // Retrievable as a runnable DCQL query (what a ceremony does).
@@ -272,11 +277,12 @@ mod tests {
         assert!(matches!(err, AppError::Validation(_)), "{err:?}");
     }
 
-    fn vetting(min: u32) -> VettingRequirements {
+    fn vetting(min: u32, min_by_method: Value) -> VettingRequirements {
         serde_json::from_value(json!({
             "version": "0.1",
             "statementType": "https://firstperson.network/endorsements/identity-vetting/0.1",
             "minStatements": min,
+            "minByMethod": min_by_method,
             "acceptedMethods": ["inPerson"],
             "eligibleVetters": { "role": "vetter" }
         }))
@@ -288,12 +294,15 @@ mod tests {
         let (_d, _s, ks) = ks().await;
         register_membership(&ks).await;
         let mut c = criterion("kernel", MEMBERSHIP_VCT);
-        c.vetting = Some(vetting(2));
+        c.vetting = Some(vetting(2, json!({ "inPerson": 1 })));
         store_accepts(&ks, &c)
             .await
             .expect("evaluable requirements store");
         let got = get_accepts(&ks, "kernel").await.unwrap().unwrap();
-        assert_eq!(got.vetting, Some(vetting(2)));
+        assert_eq!(
+            serde_json::to_value(got.vetting).unwrap(),
+            serde_json::to_value(c.vetting).unwrap()
+        );
     }
 
     #[tokio::test]
@@ -301,11 +310,23 @@ mod tests {
         let (_d, _s, ks) = ks().await;
         register_membership(&ks).await;
         let mut c = criterion("kernel", MEMBERSHIP_VCT);
-        c.vetting = Some(vetting(0));
+        c.vetting = Some(vetting(2, json!({ "video": 1 })));
         let err = store_accepts(&ks, &c)
             .await
-            .expect_err("minStatements 0 is refused");
+            .expect_err("a floor on a method the requirements do not accept is refused");
         assert!(matches!(err, AppError::Validation(_)), "{err:?}");
         assert!(get_accepts(&ks, "kernel").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn refuses_a_criterion_the_join_manifest_cannot_publish() {
+        let (_d, _s, ks) = ks().await;
+        register_membership(&ks).await;
+        let c = criterion(&"k".repeat(129), MEMBERSHIP_VCT);
+        let err = store_accepts(&ks, &c)
+            .await
+            .expect_err("a criterion id longer than the manifest allows is refused");
+        assert!(matches!(err, AppError::Validation(_)), "{err:?}");
+        assert!(list_accepts(&ks).await.unwrap().is_empty());
     }
 }

--- a/vtc-service/src/trust_tasks/conformance.rs
+++ b/vtc-service/src/trust_tasks/conformance.rs
@@ -990,19 +990,22 @@ fn table() -> Vec<Conformance> {
             s::join_requests::manifest::v0_1::Payload,
             s::join_requests::manifest::v0_1::Response,
             json!({}),
-            // Built from the SDK type, not transcribed.
-            to_v(jr::JoinRequestManifestResponseBody {
-                community_did: COMMUNITY_DID.into(),
-                criteria: vec![jr::ManifestCriterion {
-                    id: "email-verified".into(),
-                    description: Some("A verified email credential".into()),
-                    presentation_definition: json!({ "credentials": [] }),
-                    vetting: None,
-                    requirements_digest: None,
-                }],
-                // 0.1 defines no branding; the dispatcher never sets it there.
-                branding: None,
-            })
+            // Projected by the manifest read the dispatcher answers with, not
+            // transcribed.
+            to_v(
+                crate::routes::join_requests::manifest::response_v0_1(
+                    COMMUNITY_DID.into(),
+                    vec![crate::schemas::accepts::AcceptsCriterion {
+                        id: "email-verified".into(),
+                        query: json!({ "credentials": [] }),
+                        description: Some("A verified email credential".into()),
+                        vetting: None,
+                        created_at: chrono::Utc::now(),
+                        created_by_did: "did:key:zAdmin".into(),
+                    }],
+                )
+                .expect("the manifest projects the criterion"),
+            )
         ),
         checked!(
             s::join_requests::submit::v0_2::Payload,
@@ -1373,6 +1376,151 @@ fn table() -> Vec<Conformance> {
             // `RollbackResponse` — 200 with zero bytes until #1059, which
             // discarded a `noop` it had already computed.
             json!({ "generation": "1", "current": true, "noop": false })
+        ),
+        // ─── join manifest 0.2 and peer identity vetting ─────────────
+        //
+        // Every one of these handlers speaks the generated types. The
+        // responses are built the way the handlers build them — through the
+        // generated builders, or the manifest read itself — so a response the
+        // service could not produce cannot stand in for one it does.
+        checked!(
+            s::join_requests::manifest::v0_2::Payload,
+            s::join_requests::manifest::v0_2::Response,
+            json!({}),
+            to_v(
+                crate::routes::join_requests::manifest::response_v0_2(
+                    COMMUNITY_DID.into(),
+                    vec![crate::schemas::accepts::AcceptsCriterion {
+                        id: "kernel-developer".into(),
+                        query: json!({ "credentials": [] }),
+                        description: Some("Two vetters, one in person".into()),
+                        vetting: Some(
+                            serde_json::from_value(json!({
+                                "version": "0.1",
+                                "statementType":
+                                    vta_sdk::protocols::vetting::IDENTITY_VETTING_ENDORSEMENT_TYPE,
+                                "minStatements": 2,
+                                "minByMethod": { "inPerson": 1 },
+                                "acceptedMethods": ["inPerson", "video"],
+                                "eligibleVetters": { "role": "vetter" },
+                                "independence": { "requireConsistentIdentityCommitment": true }
+                            }))
+                            .expect("vetting requirements"),
+                        ),
+                        created_at: chrono::Utc::now(),
+                        created_by_did: DID.into(),
+                    }],
+                    Some(
+                        serde_json::from_value(
+                            json!({ "displayName": "Kernel", "accentColor": "#1a2b3c" }),
+                        )
+                        .expect("branding"),
+                    ),
+                )
+                .expect("the manifest projects the criterion"),
+            )
+        ),
+        checked!(
+            s::vetting::revoke_statement::v0_1::Payload,
+            s::vetting::revoke_statement::v0_1::Response,
+            json!({
+                "statementId": format!("urn:uuid:{REQUEST_ID}"),
+                "statementDigestMultibase": "zQmYimQAvAKzznkjph8xTTpuLhf21jAiUPMy7qdBp7qsU7Z",
+                "reason": "newInformation",
+            }),
+            to_v(
+                s::vetting::revoke_statement::v0_1::Response::try_from(
+                    s::vetting::revoke_statement::v0_1::Response::builder()
+                        .recorded_at(TS.parse::<DateTime<chrono::Utc>>().unwrap()),
+                )
+                .expect("revoke-statement response")
+            )
+        ),
+        checked!(
+            s::vetting::vetters::grant::v0_1::Payload,
+            s::vetting::vetters::grant::v0_1::Response,
+            json!({ "memberDid": OTHER_DID, "validitySeconds": 31_536_000 }),
+            to_v(
+                s::vetting::vetters::grant::v0_1::Response::try_from(
+                    s::vetting::vetters::grant::v0_1::Response::builder()
+                        .endorsement_id(REQUEST_ID)
+                        .credential_id(format!("urn:uuid:{REQUEST_ID}"))
+                        .valid_from(TS.parse::<DateTime<chrono::Utc>>().unwrap())
+                        .valid_until(
+                            "2027-08-23T00:00:00Z"
+                                .parse::<DateTime<chrono::Utc>>()
+                                .unwrap()
+                        ),
+                )
+                .expect("grant response")
+            )
+        ),
+        checked!(
+            s::vetting::vetters::profile::v0_1::Payload,
+            s::vetting::vetters::profile::v0_1::Response,
+            json!({
+                "listed": true,
+                "displayName": "Carol M.",
+                "languages": ["en", "de-AT"],
+                "location": { "country": "AT", "city": "Vienna" },
+                "methods": ["inPerson", "video"],
+                "acceptsDocumentation": ["passport", "none"],
+                "events": [{ "name": "Kernel Maintainers Meetup",
+                             "startDate": "2026-10-05", "endDate": "2026-10-07" }],
+            }),
+            to_v(
+                s::vetting::vetters::profile::v0_1::Response::try_from(
+                    s::vetting::vetters::profile::v0_1::Response::builder()
+                        .listed(true)
+                        .updated_at(TS.parse::<DateTime<chrono::Utc>>().unwrap()),
+                )
+                .expect("profile response")
+            )
+        ),
+        checked!(
+            s::vetting::vetters::list::v0_1::Payload,
+            s::vetting::vetters::list::v0_1::Response,
+            json!({ "language": "de", "eventFrom": "2026-10-01", "limit": 10 }),
+            to_v(
+                s::vetting::vetters::list::v0_1::Response::try_from(
+                    s::vetting::vetters::list::v0_1::Response::builder()
+                        .vetters(vec![
+                            serde_json::from_value::<s::vetting::vetters::list::v0_1::ListedVetter>(
+                                json!({
+                                    "vetterDid": OTHER_DID,
+                                    "displayName": "Carol M.",
+                                    "languages": ["en", "de-AT"],
+                                    "methods": ["inPerson"],
+                                    "acceptsDocumentation": ["passport"],
+                                    "events": [],
+                                    "grantValidUntil": TS,
+                                    "updatedAt": TS,
+                                }),
+                            )
+                            .expect("listed vetter"),
+                        ])
+                        .next_cursor(Some(
+                            s::vetting::vetters::list::v0_1::ResponseNextCursor::try_from(
+                                "b2Zmc2V0OjEw"
+                            )
+                            .expect("cursor"),
+                        )),
+                )
+                .expect("list response")
+            )
+        ),
+        checked!(
+            s::vetting::vetters::resend::v0_1::Payload,
+            s::vetting::vetters::resend::v0_1::Response,
+            json!({}),
+            to_v(
+                s::vetting::vetters::resend::v0_1::Response::try_from(
+                    s::vetting::vetters::resend::v0_1::Response::builder()
+                        .credential_id(format!("urn:uuid:{REQUEST_ID}"))
+                        .valid_until(TS.parse::<DateTime<chrono::Utc>>().unwrap()),
+                )
+                .expect("resend response")
+            )
         ),
     ]
 }

--- a/vtc-service/src/trust_tasks/mod.rs
+++ b/vtc-service/src/trust_tasks/mod.rs
@@ -63,7 +63,7 @@ use vta_sdk::protocols::join_requests::{
 };
 use vta_sdk::protocols::members::{self as mem, MemberVmcBody, MemberVmcReceiptBody};
 use vta_sdk::protocols::vetting::{
-    self as vetting_wire, RevokeStatementBody, RevokeStatementResponseBody,
+    self as vetting_wire, revoke_statement::v0_1 as revoke_statement,
 };
 
 use vti_rooms::wire as rooms_wire;
@@ -563,18 +563,20 @@ async fn handle_revoke_statement(
         Ok(did) => did,
         Err(reject) => return reject,
     };
-    let body: RevokeStatementBody = match parse_payload(&doc) {
+    let body: revoke_statement::Payload = match parse_checked_payload(&doc) {
         Ok(b) => b,
         Err(reject) => return reject,
     };
-    match crate::vetting::revocation::withdraw(state, &vetter_did, &body).await {
-        Ok(notice) => success_response(
-            &doc,
-            RevokeStatementResponseBody {
-                recorded_at: notice.recorded_at,
-                ext: None,
-            },
-        ),
+    let answer = crate::vetting::revocation::withdraw(state, &vetter_did, &body)
+        .await
+        .and_then(|notice| {
+            revoke_statement::Response::try_from(
+                revoke_statement::Response::builder().recorded_at(notice.recorded_at),
+            )
+            .map_err(|e| AppError::Internal(format!("revoke-statement response: {e}")))
+        });
+    match answer {
+        Ok(response) => success_response(&doc, response),
         Err(e) => app_error_to_reject(&doc, &e),
     }
 }
@@ -594,7 +596,7 @@ async fn handle_vetter_grant(
         Ok(did) => did,
         Err(reject) => return reject,
     };
-    let body: vetting_wire::VetterGrantBody = match parse_payload(&doc) {
+    let body: vetting_wire::vetters::grant::v0_1::Payload = match parse_checked_payload(&doc) {
         Ok(b) => b,
         Err(reject) => return reject,
     };
@@ -602,6 +604,25 @@ async fn handle_vetter_grant(
         Ok(grant) => success_response(&doc, grant.response),
         Err(e) => app_error_to_reject(&doc, &e),
     }
+}
+
+/// Parse a published task's payload as received: the JSON is validated against
+/// the published schema before it is parsed — a generated constructor can
+/// normalise what it reads — and then the rules no schema can state are applied
+/// ([`vetting_wire::read_checked`]). A payload failing any of it is
+/// `malformedRequest`.
+fn parse_checked_payload<P>(doc: &TrustTask<Value>) -> Result<P, TrustTaskOutcome>
+where
+    P: trust_tasks_rs::Payload + serde::de::DeserializeOwned + vetting_wire::CheckShape,
+{
+    vetting_wire::read_checked::<P>(&doc.payload).map_err(|e| {
+        reject_with(
+            doc,
+            RejectReason::MalformedRequest {
+                reason: format!("payload: {e}"),
+            },
+        )
+    })
 }
 
 /// A specification-extended error code, `<slug>:<local>`, as a framework code.
@@ -629,7 +650,7 @@ async fn handle_vetter_profile(
         Ok(did) => did,
         Err(reject) => return reject,
     };
-    let body: vetting_wire::VetterProfileBody = match parse_payload(&doc) {
+    let body: vetting_wire::vetters::profile::v0_1::Payload = match parse_checked_payload(&doc) {
         Ok(b) => b,
         Err(reject) => return reject,
     };
@@ -658,7 +679,7 @@ async fn handle_vetter_list(
     if let Err(reject) = resolve_holder(state, ctx, &doc).await {
         return reject;
     }
-    let body: vetting_wire::VetterListBody = match parse_payload(&doc) {
+    let body: vetting_wire::vetters::list::v0_1::Payload = match parse_checked_payload(&doc) {
         Ok(b) => b,
         Err(reject) => return reject,
     };
@@ -681,7 +702,8 @@ async fn handle_vetter_resend(
         Ok(did) => did,
         Err(reject) => return reject,
     };
-    if let Err(reject) = parse_payload::<vetting_wire::VetterResendBody>(&doc) {
+    if let Err(reject) = parse_checked_payload::<vetting_wire::vetters::resend::v0_1::Payload>(&doc)
+    {
         return reject;
     }
     match crate::vetting::vetters::resend(state, &vetter_did, &vetter_did).await {
@@ -715,10 +737,16 @@ async fn handle_manifest(
     doc: TrustTask<Value>,
     version: ManifestVersion,
 ) -> TrustTaskOutcome {
-    match crate::routes::join_requests::manifest::manifest_inner(state, version).await {
-        Ok(body) => success_response(&doc, body),
-        Err(e) => app_error_to_reject(&doc, &e),
-    }
+    use crate::routes::join_requests::manifest::{manifest_v0_1, manifest_v0_2};
+    let answer = match version {
+        ManifestVersion::V0_1 => manifest_v0_1(state)
+            .await
+            .map(|r| success_response(&doc, r)),
+        ManifestVersion::V0_2 => manifest_v0_2(state)
+            .await
+            .map(|r| success_response(&doc, r)),
+    };
+    answer.unwrap_or_else(|e| app_error_to_reject(&doc, &e))
 }
 
 // ─── status ────────────────────────────────────────────────────────────────

--- a/vtc-service/src/vetting/auto_grant.rs
+++ b/vtc-service/src/vetting/auto_grant.rs
@@ -48,7 +48,7 @@ use tokio::sync::watch;
 use tracing::{info, warn};
 
 use vta_sdk::protocols::vetting::{
-    AutoGrantConfig, AutoGrantStatus, AutoGrantSweep, DEFAULT_AUTO_GRANT_SWEEP_MINUTES,
+    AutoGrantConfig, AutoGrantStatus, AutoGrantSweep, CheckShape, DEFAULT_AUTO_GRANT_SWEEP_MINUTES,
     DEFAULT_VETTER_GRANT_VALIDITY_SECONDS, GrantOrigin,
 };
 use vti_common::audit::{AuditEvent, VetterAutoGrantConfiguredData, VetterAutoGrantSweptData};

--- a/vtc-service/src/vetting/mod.rs
+++ b/vtc-service/src/vetting/mod.rs
@@ -39,10 +39,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tracing::warn;
 
-use vta_sdk::protocols::join_requests::ManifestCriterion;
+use vta_sdk::protocols::join_requests::manifest::v0_2::Criterion as ManifestCriterion;
 use vta_sdk::protocols::vetting::{
-    COMMUNITY_ROLE_ENDORSEMENT_TYPE, IDENTITY_VETTING_ENDORSEMENT_TYPE, InvitationRequirement,
-    VettingRequirements,
+    COMMUNITY_ROLE_ENDORSEMENT_TYPE, IDENTITY_VETTING_ENDORSEMENT_TYPE, VettingRequirements,
+    VettingRequirementsInvitation,
 };
 use vta_sdk::vetting::requirements::{REQUIREMENTS_DIGEST_MEMBER, StatementFacts, evaluate};
 use vta_sdk::vetting::statement::verify_statement;
@@ -50,7 +50,7 @@ use vti_common::error::AppError;
 
 use crate::endorsements::endorsements_for_subject;
 use crate::members::storage::get_member;
-use crate::routes::join_requests::manifest::{ManifestVersion, manifest_criterion};
+use crate::routes::join_requests::manifest::manifest_criterion;
 use crate::schemas::accepts::list_accepts;
 use crate::server::AppState;
 
@@ -133,7 +133,7 @@ pub async fn vetting_facts(
     let mut projected = Vec::new();
     for stored in list_accepts(&state.schemas_ks).await? {
         if stored.vetting.is_some() {
-            projected.push(manifest_criterion(stored, ManifestVersion::V0_2)?);
+            projected.push(manifest_criterion(stored)?);
         }
     }
     let applicant_digest = extensions
@@ -215,10 +215,8 @@ pub async fn vetting_facts(
             verified: true,
             eligible,
             revoked,
-            method: Some(endorsement.method.as_str().to_string()),
-            declared_relationship: serde_json::to_value(endorsement.declared_relationship)
-                .ok()
-                .and_then(|v| v.as_str().map(str::to_string)),
+            method: Some(endorsement.method.to_string()),
+            declared_relationship: Some(endorsement.declared_relationship.to_string()),
             counted: false,
             failures,
         };
@@ -230,8 +228,16 @@ pub async fn vetting_facts(
                 statement_id: verified.id().to_string(),
                 vetter: verified.issuer().to_string(),
                 method: endorsement.method,
-                claims_verified: endorsement.claims_verified.clone(),
-                document_classes: endorsement.document_classes.clone(),
+                claims_verified: endorsement
+                    .claims_verified
+                    .iter()
+                    .map(|c| c.as_str().to_owned())
+                    .collect(),
+                document_classes: endorsement
+                    .document_classes
+                    .iter()
+                    .map(|d| d.as_str().to_owned())
+                    .collect(),
                 declared_relationship: endorsement.declared_relationship,
                 identity_commitment: endorsement.identity_commitment.clone(),
                 valid_from: verified.valid_from(),
@@ -265,13 +271,13 @@ pub async fn vetting_facts(
         by_method: evaluation
             .by_method
             .iter()
-            .map(|(m, n)| (m.as_str().to_string(), *n))
+            .map(|(m, n)| (m.to_string(), *n))
             .collect(),
         commitments_consistent: evaluation.commitments_consistent,
         independence_ok: evaluation.independence_ok,
         invitation_required: matches!(
             requirements.invitation,
-            Some(InvitationRequirement::Required)
+            Some(VettingRequirementsInvitation::Required)
         ),
         satisfied: evaluation.satisfied(),
         needs: evaluation.needs.iter().map(|n| n.to_wire()).collect(),
@@ -296,7 +302,7 @@ pub fn expand_needs(needs: &mut Vec<String>, facts: Option<&VettingFacts>) {
 }
 
 /// The criterion a submission is evaluated under.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 struct Selected {
     criterion_id: String,
     requirements: VettingRequirements,
@@ -314,7 +320,7 @@ fn select_criterion(
     let named = applicant_digest.and_then(|d| {
         projected
             .iter()
-            .position(|c| c.requirements_digest.as_deref() == Some(d))
+            .position(|c| c.requirements_digest.as_ref().map(|r| r.as_str()) == Some(d))
     });
     let (index, matches) = match named {
         Some(i) => (i, true),
@@ -322,9 +328,12 @@ fn select_criterion(
     };
     let chosen = projected.into_iter().nth(index)?;
     Some(Selected {
-        criterion_id: chosen.id,
+        criterion_id: chosen.id.as_str().to_owned(),
         requirements: chosen.vetting?,
-        digest: chosen.requirements_digest.unwrap_or_default(),
+        digest: chosen
+            .requirements_digest
+            .map(String::from)
+            .unwrap_or_default(),
         applicant_digest_matches: matches,
     })
 }
@@ -389,39 +398,49 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// A digest-shaped value per criterion id.
+    fn digest(id: &str) -> String {
+        format!("zQm{}", id.repeat(20))
+    }
+
     fn criterion(id: &str, min: u32) -> ManifestCriterion {
-        ManifestCriterion {
-            id: id.into(),
-            description: None,
-            presentation_definition: json!({}),
-            vetting: Some(
-                serde_json::from_value(json!({
-                    "version": "0.1",
-                    "statementType": IDENTITY_VETTING_ENDORSEMENT_TYPE,
-                    "minStatements": min,
-                    "acceptedMethods": ["inPerson"],
-                    "eligibleVetters": { "role": "vetter" }
-                }))
-                .unwrap(),
-            ),
-            requirements_digest: Some(format!("z{id}")),
-        }
+        serde_json::from_value(json!({
+            "id": id,
+            "presentationDefinition": {},
+            "vetting": {
+                "version": "0.1",
+                "statementType": IDENTITY_VETTING_ENDORSEMENT_TYPE,
+                "minStatements": min,
+                "acceptedMethods": ["inPerson"],
+                "eligibleVetters": { "role": "vetter" }
+            },
+            "requirementsDigest": digest(id),
+        }))
+        .unwrap()
     }
 
     #[test]
     fn the_criterion_the_applicant_named_is_the_one_applied() {
-        let s = select_criterion(vec![criterion("a", 1), criterion("b", 2)], Some("zb")).unwrap();
+        let s = select_criterion(
+            vec![criterion("a", 1), criterion("b", 2)],
+            Some(&digest("b")),
+        )
+        .unwrap();
         assert_eq!(s.criterion_id, "b");
         assert!(s.applicant_digest_matches);
-        assert_eq!(s.requirements.min_statements, 2);
+        assert_eq!(s.requirements.min_statements.get(), 2);
     }
 
     #[test]
     fn an_unknown_or_absent_digest_falls_back_to_the_first_and_says_so() {
-        let s = select_criterion(vec![criterion("a", 1), criterion("b", 2)], Some("zold")).unwrap();
+        let s = select_criterion(
+            vec![criterion("a", 1), criterion("b", 2)],
+            Some(&digest("c")),
+        )
+        .unwrap();
         assert_eq!(s.criterion_id, "a");
         assert!(!s.applicant_digest_matches);
-        assert!(select_criterion(vec![], Some("za")).is_none());
+        assert!(select_criterion(vec![], Some(&digest("a"))).is_none());
     }
 
     fn facts_with_needs(needs: &[&str]) -> VettingFacts {

--- a/vtc-service/src/vetting/profiles.rs
+++ b/vtc-service/src/vetting/profiles.rs
@@ -7,6 +7,10 @@
 //! statement; the community stores it and decides only who may publish one
 //! and who appears in a listing.
 //!
+//! Both tasks' payloads and responses are the generated
+//! `vta_sdk::protocols::vetting::vetters::{profile, list}::v0_1` types, and a
+//! stored profile is the profile payload as published.
+//!
 //! ## Who may publish, and who is listed
 //!
 //! Publishing needs what counting a statement needs: an active member holding a
@@ -23,7 +27,9 @@
 //!
 //! The published profile (events already over are left out), the vetter's DID
 //! and the grant's expiry. Nothing about the member row, their other
-//! credentials or how they joined.
+//! credentials or how they joined. A listing row is read as the listing
+//! schema's own `ListedVetter`, which is closed: a profile member the listing
+//! does not define fails the read instead of being disclosed.
 //!
 //! ## Order and pages
 //!
@@ -46,16 +52,20 @@
 //! MAY, Conformance 4).
 
 use std::cmp::Ordering;
+use std::num::NonZeroU64;
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tracing::{info, warn};
 
+use vta_sdk::protocols::vetting::vetters::{
+    list::v0_1 as list_wire, profile::v0_1 as profile_wire,
+};
 use vta_sdk::protocols::vetting::{
-    DEFAULT_VETTER_LIST_LIMIT, ListedVetter, VetterEvent, VetterListBody, VetterListResponseBody,
-    VetterProfileBody, VetterProfileResponseBody, VetterProfileSummary,
+    CheckShape, DEFAULT_VETTER_LIST_LIMIT, VetterProfileSummary, has_event_filter,
 };
 use vti_common::audit::{AuditEvent, VetterProfileDeletedData, VetterProfileUpdatedData};
 use vti_common::error::AppError;
@@ -76,13 +86,13 @@ pub const DELETED_GRANT_REVOKED: &str = "grantRevoked";
 pub const DELETED_DEPARTED: &str = "departed";
 
 /// A stored profile.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StoredProfile {
     /// The vetter — the authenticated sender who published it.
     pub vetter_did: String,
-    /// The profile as published.
-    pub profile: VetterProfileBody,
+    /// The profile as published: the `vtc/vetting/vetters/profile/0.1` payload.
+    pub profile: profile_wire::Payload,
     /// When it was published.
     pub updated_at: DateTime<Utc>,
     /// The publishing document's `issuedAt`, when it carried one.
@@ -93,13 +103,14 @@ pub struct StoredProfile {
 impl StoredProfile {
     /// What an admin sees of it.
     pub fn summary(&self) -> VetterProfileSummary {
+        let p = &self.profile;
         VetterProfileSummary {
-            listed: self.profile.listed,
-            display_name: self.profile.display_name.clone(),
-            country: self.profile.location.as_ref().map(|l| l.country.clone()),
-            languages: self.profile.languages.clone(),
-            methods: self.profile.methods.clone(),
-            event_count: u32::try_from(self.profile.events.len()).unwrap_or(u32::MAX),
+            listed: p.listed,
+            display_name: p.display_name.as_ref().map(|n| n.as_str().to_owned()),
+            country: p.location.as_ref().map(|l| l.country.as_str().to_owned()),
+            languages: p.languages.iter().map(|l| l.as_str().to_owned()).collect(),
+            methods: p.methods.0.clone(),
+            event_count: u32::try_from(p.events.len()).unwrap_or(u32::MAX),
             updated_at: self.updated_at,
         }
     }
@@ -152,7 +163,7 @@ pub async fn delete_profile(ks: &KeyspaceHandle, vetter_did: &str) -> Result<boo
 ///
 /// # Errors
 ///
-/// [`AppError::Validation`] for a body that breaks its schema bounds or a
+/// [`AppError::Validation`] for a body that breaks its specification or a
 /// document older than the one the stored profile came from, and
 /// [`AppError::Forbidden`] when the sender is not an active member holding a
 /// live vetter grant — the Trust Task dispatcher answers that with
@@ -160,9 +171,9 @@ pub async fn delete_profile(ks: &KeyspaceHandle, vetter_did: &str) -> Result<boo
 pub async fn publish(
     state: &AppState,
     vetter_did: &str,
-    body: &VetterProfileBody,
+    body: &profile_wire::Payload,
     issued_at: Option<DateTime<Utc>>,
-) -> Result<VetterProfileResponseBody, AppError> {
+) -> Result<profile_wire::Response, AppError> {
     body.check_shape()
         .map_err(|e| AppError::Validation(e.to_string()))?;
     let now = Utc::now();
@@ -209,10 +220,12 @@ pub async fn publish(
             .await?;
     }
     info!(vetter = %vetter_did, listed = body.listed, "vetter profile published");
-    Ok(VetterProfileResponseBody {
-        listed: body.listed,
-        updated_at: now,
-    })
+    profile_wire::Response::try_from(
+        profile_wire::Response::builder()
+            .listed(body.listed)
+            .updated_at(now),
+    )
+    .map_err(|e| AppError::Internal(format!("vetter profile response: {e}")))
 }
 
 /// Delete `vetter_did`'s profile when they no longer hold a live grant, and
@@ -263,12 +276,12 @@ pub(crate) async fn after_grant_revoked(
 ///
 /// # Errors
 ///
-/// [`AppError::Validation`] for a request that breaks its bounds or carries a
-/// cursor this community did not issue for these filters.
+/// [`AppError::Validation`] for a request that breaks its specification or
+/// carries a cursor this community did not issue for these filters.
 pub async fn list(
     state: &AppState,
-    body: &VetterListBody,
-) -> Result<VetterListResponseBody, AppError> {
+    body: &list_wire::Payload,
+) -> Result<list_wire::Response, AppError> {
     body.check_shape()
         .map_err(|e| AppError::Validation(e.to_string()))?;
     let tag = filter_tag(body);
@@ -276,14 +289,17 @@ pub async fn list(
         Some(cursor) => decode_cursor(cursor, &tag)?,
         None => 0,
     };
-    let limit = usize::try_from(body.limit.unwrap_or(DEFAULT_VETTER_LIST_LIMIT))
-        .unwrap_or(usize::MAX)
-        .max(1);
+    let limit = usize::try_from(
+        body.limit
+            .map_or(DEFAULT_VETTER_LIST_LIMIT, NonZeroU64::get),
+    )
+    .unwrap_or(usize::MAX)
+    .max(1);
     let now = Utc::now();
     let today = now.date_naive();
 
     let live = vetters::live_grants(state, now).await?;
-    let mut rows: Vec<(SortKey, ListedVetter)> = Vec::new();
+    let mut rows: Vec<(SortKey, list_wire::ListedVetter)> = Vec::new();
     for stored in list_profiles(&state.vetter_profiles_ks).await? {
         if !stored.profile.listed {
             continue;
@@ -299,25 +315,36 @@ pub async fn list(
         };
         let sort = SortKey {
             event_date,
-            name: stored.profile.display_name.clone(),
+            name: stored
+                .profile
+                .display_name
+                .as_ref()
+                .map(|n| n.as_str().to_owned()),
             did: stored.vetter_did.clone(),
         };
-        rows.push((sort, listed(stored, grant_valid_until, today)));
+        rows.push((sort, listed(stored, grant_valid_until, today)?));
     }
     rows.sort_by(|(a, _), (b, _)| a.cmp(b));
 
     let total = rows.len();
-    let vetters: Vec<ListedVetter> = rows
+    let vetters: Vec<list_wire::ListedVetter> = rows
         .into_iter()
         .skip(offset)
         .take(limit)
         .map(|(_, v)| v)
         .collect();
     let next = offset.saturating_add(limit);
-    Ok(VetterListResponseBody {
-        vetters,
-        next_cursor: (next < total).then(|| encode_cursor(next, &tag)),
-    })
+    let next_cursor = (next < total)
+        .then(|| encode_cursor(next, &tag))
+        .map(list_wire::ResponseNextCursor::try_from)
+        .transpose()
+        .map_err(|e| AppError::Internal(format!("vetter listing cursor: {e}")))?;
+    list_wire::Response::try_from(
+        list_wire::Response::builder()
+            .vetters(vetters)
+            .next_cursor(next_cursor),
+    )
+    .map_err(|e| AppError::Internal(format!("vetter listing: {e}")))
 }
 
 /// The listing order: earliest matching event first when the request filters
@@ -356,8 +383,8 @@ impl PartialOrd for SortKey {
 /// otherwise the earliest matching event's start date when the request filters
 /// on events, and `Some(None)` when it does not.
 fn matches(
-    profile: &VetterProfileBody,
-    body: &VetterListBody,
+    profile: &profile_wire::Payload,
+    body: &list_wire::Payload,
     today: NaiveDate,
 ) -> Option<Option<NaiveDate>> {
     if let Some(language) = &body.language {
@@ -379,38 +406,51 @@ fn matches(
     }
     if let Some(region) = &body.region
         && !location
-            .and_then(|l| l.region.as_deref())
+            .and_then(|l| l.region.as_ref())
             .is_some_and(|r| same_text(r, region))
     {
         return None;
     }
     if let Some(city) = &body.city
         && !location
-            .and_then(|l| l.city.as_deref())
+            .and_then(|l| l.city.as_ref())
             .is_some_and(|c| same_text(c, city))
     {
         return None;
     }
+    // Each schema generates its own `VettingMethod` from the one shared
+    // vocabulary; they compare by wire value.
     if let Some(method) = body.method
-        && !profile.methods.contains(&method)
+        && !profile
+            .methods
+            .iter()
+            .any(|m| m.to_string() == method.to_string())
     {
         return None;
     }
-    if !body.has_event_filter() {
+    if !has_event_filter(body) {
         return Some(None);
     }
-    let name = body.event_name.as_deref().map(str::to_lowercase);
+    let name = body.event_name.as_ref().map(|n| n.to_lowercase());
     profile
         .events
         .iter()
-        .filter(|e| e.end_date >= today)
-        .filter(|e| body.event_from.is_none_or(|from| e.end_date >= from))
-        .filter(|e| body.event_to.is_none_or(|to| e.start_date <= to))
+        .filter(|e| e.end_date.0 >= today)
+        .filter(|e| {
+            body.event_from
+                .as_ref()
+                .is_none_or(|from| e.end_date.0 >= from.0)
+        })
+        .filter(|e| {
+            body.event_to
+                .as_ref()
+                .is_none_or(|to| e.start_date.0 <= to.0)
+        })
         .filter(|e| {
             name.as_deref()
                 .is_none_or(|n| e.name.to_lowercase().contains(n))
         })
-        .map(|e| e.start_date)
+        .map(|e| e.start_date.0)
         .min()
         .map(Some)
 }
@@ -419,41 +459,56 @@ fn same_text(a: &str, b: &str) -> bool {
     a.to_lowercase() == b.to_lowercase()
 }
 
+/// One listing row: the published profile with only the events that have not
+/// ended, the vetter's DID and the grant's expiry.
+///
+/// The profile is read as the listing schema's `ListedVetter`. The two
+/// schemas share their member definitions, and `ListedVetter` is closed, so a
+/// member a profile gains that a listing does not define fails here rather than
+/// reaching an applicant.
 fn listed(
     stored: StoredProfile,
     grant_valid_until: DateTime<Utc>,
     today: NaiveDate,
-) -> ListedVetter {
-    let p = stored.profile;
-    ListedVetter {
-        vetter_did: stored.vetter_did,
-        display_name: p.display_name,
-        languages: p.languages,
-        location: p.location,
-        methods: p.methods,
-        accepts_documentation: p.accepts_documentation,
-        availability: p.availability,
-        contact_hint: p.contact_hint,
-        events: p
-            .events
-            .into_iter()
-            .filter(|e: &VetterEvent| e.end_date >= today)
-            .collect(),
-        grant_valid_until,
-        updated_at: stored.updated_at,
-    }
+) -> Result<list_wire::ListedVetter, AppError> {
+    let internal =
+        |e: &dyn std::fmt::Display| AppError::Internal(format!("vetter listing row: {e}"));
+    let current: Vec<&profile_wire::VetterEvent> = stored
+        .profile
+        .events
+        .iter()
+        .filter(|e| e.end_date.0 >= today)
+        .collect();
+    let events = serde_json::to_value(current).map_err(|e| internal(&e))?;
+    let mut row = serde_json::to_value(&stored.profile).map_err(|e| internal(&e))?;
+    let fields = row
+        .as_object_mut()
+        .ok_or_else(|| internal(&"a profile is not an object"))?;
+    // Not part of a listing entry: that the profile is listed (it is), and the
+    // profile document's extensions.
+    fields.remove("listed");
+    fields.remove("ext");
+    fields.insert("events".into(), events);
+    fields.insert("vetterDid".into(), Value::String(stored.vetter_did));
+    fields.insert(
+        "grantValidUntil".into(),
+        serde_json::to_value(grant_valid_until).map_err(|e| internal(&e))?,
+    );
+    fields.insert(
+        "updatedAt".into(),
+        serde_json::to_value(stored.updated_at).map_err(|e| internal(&e))?,
+    );
+    serde_json::from_value(row).map_err(|e| internal(&e))
 }
 
 /// A short digest of the request's filters — everything but `limit`, `cursor`
 /// and `ext` — that a cursor is bound to.
-fn filter_tag(body: &VetterListBody) -> String {
+fn filter_tag(body: &list_wire::Payload) -> String {
     use sha2::{Digest, Sha256};
-    let filters = VetterListBody {
-        limit: None,
-        cursor: None,
-        ext: None,
-        ..body.clone()
-    };
+    let mut filters = body.clone();
+    filters.limit = None;
+    filters.cursor = None;
+    filters.ext = None;
     let bytes = serde_json::to_vec(&filters).unwrap_or_default();
     hex::encode(&Sha256::digest(&bytes)[..8])
 }
@@ -483,9 +538,8 @@ fn decode_cursor(cursor: &str, tag: &str) -> Result<usize, AppError> {
 mod tests {
     use super::*;
     use serde_json::json;
-    use vta_sdk::protocols::vetting::VettingMethod;
 
-    fn profile(value: serde_json::Value) -> VetterProfileBody {
+    fn profile(value: serde_json::Value) -> profile_wire::Payload {
         serde_json::from_value(value).unwrap()
     }
 
@@ -493,7 +547,7 @@ mod tests {
         NaiveDate::from_ymd_opt(2026, 9, 11).unwrap()
     }
 
-    fn carol() -> VetterProfileBody {
+    fn carol() -> profile_wire::Payload {
         profile(json!({
             "listed": true,
             "displayName": "Carol",
@@ -509,7 +563,7 @@ mod tests {
         }))
     }
 
-    fn filter(value: serde_json::Value) -> VetterListBody {
+    fn filter(value: serde_json::Value) -> list_wire::Payload {
         serde_json::from_value(value).unwrap()
     }
 
@@ -519,7 +573,6 @@ mod tests {
         assert!(matches(&p, &filter(json!({ "language": "de" })), today()).is_some());
         assert!(matches(&p, &filter(json!({ "language": "DE-at" })), today()).is_some());
         assert!(matches(&p, &filter(json!({ "language": "en" })), today()).is_some());
-        assert!(matches(&p, &filter(json!({ "language": "d" })), today()).is_none());
         assert!(matches(&p, &filter(json!({ "language": "de-CH" })), today()).is_none());
         assert!(matches(&p, &filter(json!({ "language": "fr" })), today()).is_none());
     }
@@ -587,7 +640,10 @@ mod tests {
         );
         assert_eq!(date(None, None, Some("old meetup")), None);
         // No event filter at all.
-        assert_eq!(matches(&p, &VetterListBody::default(), today()), Some(None));
+        assert_eq!(
+            matches(&p, &list_wire::Payload::default(), today()),
+            Some(None)
+        );
     }
 
     #[test]
@@ -636,10 +692,13 @@ mod tests {
             updated_at: Utc::now(),
             issued_at: None,
         };
-        let row = listed(stored, Utc::now(), today());
+        let row = listed(stored, Utc::now(), today()).unwrap();
         let names: Vec<&str> = row.events.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, ["Kernel Maintainer Summit", "Plumbers"]);
-        assert_eq!(row.methods, vec![VettingMethod::InPerson]);
+        assert_eq!(row.methods.0, vec![list_wire::VettingMethod::InPerson]);
+        assert_eq!(row.vetter_did.as_str(), "did:key:zCarol");
+        let wire = serde_json::to_value(&row).unwrap();
+        assert!(wire.get("listed").is_none() && wire.get("ext").is_none());
     }
 
     #[test]

--- a/vtc-service/src/vetting/revocation.rs
+++ b/vtc-service/src/vetting/revocation.rs
@@ -27,7 +27,10 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::info;
 
-use vta_sdk::protocols::vetting::{RevocationReason, RevokeStatementBody};
+use vta_sdk::protocols::vetting::CheckShape;
+use vta_sdk::protocols::vetting::revoke_statement::v0_1::{
+    Payload as RevokeStatement, PayloadReason as RevocationReason,
+};
 use vti_common::audit::{AuditEvent, VettingStatementRevokedData};
 use vti_common::error::AppError;
 use vti_common::store::KeyspaceHandle;
@@ -98,7 +101,7 @@ pub async fn is_revoked(
 pub async fn record(
     ks: &KeyspaceHandle,
     issuer: &str,
-    body: &RevokeStatementBody,
+    body: &RevokeStatement,
     now: DateTime<Utc>,
 ) -> Result<(RevocationNotice, bool), AppError> {
     body.check_shape()
@@ -111,8 +114,8 @@ pub async fn record(
     }
     let notice = RevocationNotice {
         issuer: issuer.to_string(),
-        statement_id: body.statement_id.clone(),
-        statement_digest_multibase: body.statement_digest_multibase.clone(),
+        statement_id: body.statement_id.as_str().to_owned(),
+        statement_digest_multibase: body.statement_digest_multibase.as_str().to_owned(),
         reason: body.reason,
         recorded_at: now,
     };
@@ -143,7 +146,7 @@ pub async fn list_notices(ks: &KeyspaceHandle) -> Result<Vec<RevocationNotice>, 
 pub async fn withdraw(
     state: &AppState,
     vetter_did: &str,
-    body: &RevokeStatementBody,
+    body: &RevokeStatement,
 ) -> Result<RevocationNotice, AppError> {
     if get_member(&state.members_ks, vetter_did).await?.is_none() {
         return Err(AppError::Forbidden(
@@ -161,10 +164,7 @@ pub async fn withdraw(
                     AuditEvent::VettingStatementRevoked(VettingStatementRevokedData {
                         statement_id: notice.statement_id.clone(),
                         statement_digest_multibase: notice.statement_digest_multibase.clone(),
-                        reason: notice
-                            .reason
-                            .and_then(|r| serde_json::to_value(r).ok())
-                            .and_then(|v| v.as_str().map(str::to_string)),
+                        reason: notice.reason.map(|r| r.to_string()),
                     }),
                 )
                 .await?;
@@ -191,13 +191,13 @@ mod tests {
         (dir, store, ks)
     }
 
-    fn body(id: &str, digest: &str) -> RevokeStatementBody {
-        RevokeStatementBody {
-            statement_id: id.into(),
-            statement_digest_multibase: digest.into(),
-            reason: Some(RevocationReason::Mistake),
-            ext: None,
-        }
+    fn body(id: &str, digest: &str) -> RevokeStatement {
+        serde_json::from_value(json!({
+            "statementId": id,
+            "statementDigestMultibase": digest,
+            "reason": "mistake",
+        }))
+        .unwrap()
     }
 
     fn digest_of(v: serde_json::Value) -> String {
@@ -261,34 +261,43 @@ mod tests {
         .unwrap();
         assert!(!created);
         assert_eq!(again.recorded_at, first.recorded_at);
+        assert_eq!(again.reason, Some(RevocationReason::Mistake));
     }
 
+    /// A digest the schema's pattern admits but that decodes to no multihash
+    /// is refused, and names nothing.
     #[tokio::test]
-    async fn a_malformed_digest_is_refused_and_names_nothing() {
+    async fn a_digest_that_does_not_decode_is_refused_and_names_nothing() {
         let (_d, _s, ks) = ks().await;
+        let undecodable = "z1111111111111111111111";
         let err = record(
             &ks,
             "did:key:zCarol",
-            &body("urn:uuid:s1", "not-multibase"),
+            &body("urn:uuid:s1", undecodable),
             Utc::now(),
         )
         .await
         .unwrap_err();
         assert!(matches!(err, AppError::Validation(_)), "{err:?}");
         assert!(
-            !is_revoked(&ks, "did:key:zCarol", "urn:uuid:s1", "not-multibase")
+            !is_revoked(&ks, "did:key:zCarol", "urn:uuid:s1", undecodable)
                 .await
                 .unwrap()
         );
     }
 
-    #[tokio::test]
-    async fn an_empty_statement_id_is_refused() {
-        let (_d, _s, ks) = ks().await;
+    #[test]
+    fn a_notice_that_breaks_its_schema_never_reaches_the_store() {
         let digest = digest_of(json!({ "statement": 1 }));
-        assert!(matches!(
-            record(&ks, "did:key:zCarol", &body("  ", &digest), Utc::now()).await,
-            Err(AppError::Validation(_))
-        ));
+        for (id, digest) in [("  ", digest.as_str()), ("urn:uuid:s1", "not-multibase")] {
+            assert!(
+                serde_json::from_value::<RevokeStatement>(json!({
+                    "statementId": id,
+                    "statementDigestMultibase": digest,
+                }))
+                .is_err(),
+                "{id} / {digest}"
+            );
+        }
     }
 }

--- a/vtc-service/src/vetting/vetters.rs
+++ b/vtc-service/src/vetting/vetters.rs
@@ -40,10 +40,12 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use vta_sdk::protocols::members::ENDORSEMENT_CREDENTIAL_TYPE;
+use vta_sdk::protocols::vetting::vetters::{
+    grant::v0_1 as grant_wire, resend::v0_1 as resend_wire,
+};
 use vta_sdk::protocols::vetting::{
-    COMMUNITY_ROLE_ENDORSEMENT_TYPE, DEFAULT_VETTER_GRANT_VALIDITY_SECONDS, GrantOrigin,
-    VETTER_ROLE, VetterGrantBody, VetterGrantResponseBody, VetterGrantRow,
-    VetterResendResponseBody, role_matches,
+    COMMUNITY_ROLE_ENDORSEMENT_TYPE, CheckShape, DEFAULT_VETTER_GRANT_VALIDITY_SECONDS,
+    GrantOrigin, VETTER_ROLE, VetterGrantRow, role_matches,
 };
 use vti_common::audit::{
     AuditEvent, AuditWriter, CredentialIssuedData, CustomEndorsementRevokedData,
@@ -72,7 +74,7 @@ pub(crate) static GRANT_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(
 #[derive(Debug)]
 pub struct VetterGrant {
     /// The wire answer.
-    pub response: VetterGrantResponseBody,
+    pub response: grant_wire::Response,
     /// The credential this call minted, or `None` when an existing live grant
     /// was returned instead.
     pub credential: Option<JsonValue>,
@@ -260,10 +262,16 @@ async fn require_admin(state: &AppState, actor_did: &str) -> Result<(), AppError
 pub async fn grant(
     state: &AppState,
     actor_did: &str,
-    body: &VetterGrantBody,
+    body: &grant_wire::Payload,
 ) -> Result<VetterGrant, AppError> {
     body.check_shape()
         .map_err(|e| AppError::Validation(e.to_string()))?;
+    // The schema's `minimum` has already refused a negative validity.
+    let validity_seconds = body
+        .validity_seconds
+        .map(u64::try_from)
+        .transpose()
+        .map_err(|_| AppError::Validation("validitySeconds must not be negative".into()))?;
     require_admin(state, actor_did).await?;
     let grant = {
         let _guard = GRANT_LOCK.lock().await;
@@ -271,7 +279,7 @@ pub async fn grant(
             state,
             actor_did,
             &body.member_did,
-            body.validity_seconds,
+            validity_seconds,
             GrantOrigin::Manual,
         )
         .await?
@@ -465,7 +473,7 @@ pub async fn resend(
     state: &AppState,
     actor_did: &str,
     member_did: &str,
-) -> Result<VetterResendResponseBody, AppError> {
+) -> Result<resend_wire::Response, AppError> {
     let row = live_grant(state, member_did, Utc::now())
         .await?
         .ok_or_else(|| AppError::NotFound(format!("{member_did} holds no live vetter grant")))?;
@@ -500,10 +508,12 @@ pub async fn resend(
             .await?;
     }
     info!(member = %member_did, endorsement_id = %row.id, "vetter grant credential delivered again");
-    Ok(VetterResendResponseBody {
-        credential_id: row.vec_id,
-        valid_until,
-    })
+    resend_wire::Response::try_from(
+        resend_wire::Response::builder()
+            .credential_id(row.vec_id)
+            .valid_until(valid_until),
+    )
+    .map_err(|e| AppError::Internal(format!("vetter resend response: {e}")))
 }
 
 /// [`resend`] for `POST /v1/vetting/vetters/{memberDid}/resend`: admins only.
@@ -511,7 +521,7 @@ pub async fn resend_as_admin(
     state: &AppState,
     actor_did: &str,
     member_did: &str,
-) -> Result<VetterResendResponseBody, AppError> {
+) -> Result<resend_wire::Response, AppError> {
     require_admin(state, actor_did).await?;
     resend(state, actor_did, member_did).await
 }
@@ -678,16 +688,18 @@ pub(crate) async fn audit_revoked_grant(
     Ok(())
 }
 
-fn response_for(row: &Endorsement) -> Result<VetterGrantResponseBody, AppError> {
-    Ok(VetterGrantResponseBody {
-        endorsement_id: row.id.to_string(),
-        credential_id: row.vec_id.clone(),
-        valid_from: row.created_at,
-        valid_until: row
-            .valid_until
-            .ok_or_else(|| AppError::Internal("vetter grant row has no validUntil".into()))?,
-        ext: None,
-    })
+fn response_for(row: &Endorsement) -> Result<grant_wire::Response, AppError> {
+    let valid_until = row
+        .valid_until
+        .ok_or_else(|| AppError::Internal("vetter grant row has no validUntil".into()))?;
+    grant_wire::Response::try_from(
+        grant_wire::Response::builder()
+            .endorsement_id(row.id.to_string())
+            .credential_id(row.vec_id.clone())
+            .valid_from(row.created_at)
+            .valid_until(valid_until),
+    )
+    .map_err(|e| AppError::Internal(format!("vetter grant response: {e}")))
 }
 
 fn timestamp(credential: &JsonValue, member: &str) -> Result<DateTime<Utc>, AppError> {

--- a/vtc-service/tests/join_didcomm.rs
+++ b/vtc-service/tests/join_didcomm.rs
@@ -99,8 +99,8 @@ use vtc_service::test_support::{MockVtcDidcomm, ReplyOutcome};
 use vta_sdk::protocols::credential_exchange::{ISSUE as CREDENTIAL_ISSUE_TYPE, IssueBody};
 use vta_sdk::protocols::join_requests::{
     JOIN_REQUEST_MANIFEST_TYPE, JOIN_REQUEST_STATUS_TYPE, JOIN_REQUEST_SUBMIT_TYPE,
-    JoinRequestManifestResponseBody, JoinRequestStatusBody, JoinRequestStatusResponseBody,
-    JoinRequestSubmitBody, VerdictEffect, VerdictResponse,
+    JoinRequestStatusBody, JoinRequestStatusResponseBody, JoinRequestSubmitBody, VerdictEffect,
+    VerdictResponse, manifest,
 };
 
 /// The `payload` of a Trust Task `#response` document (where every verb's
@@ -251,18 +251,18 @@ async fn didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_deliver
     let request_id = verdict.request_id;
 
     // 2. Discover the community's join evidence over DIDComm (real
-    //    `manifest_inner`) — the seeded DCQL Accepts criterion.
-    let manifest: JoinRequestManifestResponseBody = serde_json::from_value(response_payload(
+    //    manifest read) — the seeded DCQL Accepts criterion.
+    let manifest: manifest::v0_1::Response = serde_json::from_value(response_payload(
         mock.client
             .request(&vtc_did, JOIN_REQUEST_MANIFEST_TYPE, json!({}))
             .await,
     ))
     .expect("manifest response");
-    assert_eq!(manifest.community_did, vtc_did);
+    assert_eq!(manifest.community_did.as_str(), vtc_did);
     let criterion = manifest
         .criteria
         .iter()
-        .find(|c| c.id == "membership")
+        .find(|c| c.id.as_str() == "membership")
         .expect("manifest advertises the membership criterion");
 
     // 3. OpenVTC D4: select a held credential against the manifest's DCQL and
@@ -282,7 +282,9 @@ async fn didcomm_join_round_trips_submit_manifest_status_approve_and_vmc_deliver
             "credentialSubject": subject,
         }),
     };
-    let candidates = select_credentials(&criterion.presentation_definition, &[held])
+    let presentation_definition =
+        serde_json::Value::Object(criterion.presentation_definition.clone());
+    let candidates = select_credentials(&presentation_definition, &[held])
         .expect("held credential satisfies the manifest DCQL");
     let vp_token = build_vp_token(
         &candidates,

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -2806,6 +2806,26 @@ async fn only_a_member_holding_a_live_grant_may_publish_a_profile() {
 }
 
 #[tokio::test]
+async fn a_profile_whose_event_url_is_not_an_absolute_https_uri_is_malformed() {
+    // An event `url` is `format: uri`, which the schema validator does not
+    // assert: the community refuses one by hand.
+    let fix = build_fixture().await;
+    let (carol, _) = did_key_secret([0x11; 32]);
+    seed_vetter(&fix, &carol).await;
+    for url in [
+        "https://kernel.example/maintainers meetup",
+        "https://kernel.example/meetup\u{7}",
+        "http://kernel.example/meetup",
+    ] {
+        let mut profile = carols_profile(true);
+        profile["events"][1]["url"] = json!(url);
+        let (status, body) = publish_profile(&fix, [0x11; 32], profile).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{url:?}: {body}");
+        assert_eq!(tt_error_code(&body), "malformedRequest", "{url:?}");
+    }
+}
+
+#[tokio::test]
 async fn unlisting_hides_a_profile_and_revoking_the_grant_deletes_it() {
     use vtc_service::vetting::profiles::get_profile;
     let fix = build_fixture().await;
@@ -2952,14 +2972,22 @@ async fn branding_is_published_on_manifest_0_2_only() {
     assert_eq!(status, StatusCode::OK, "{body}");
     assert_eq!(body["accentColor"], "#1a2b3c", "stored in lower case");
 
-    let (status, body) = admin_rest(
-        &fix,
-        "PUT",
-        "/v1/community/branding",
-        Some(json!({ "logoUrl": "http://kernel.example/logo.svg" })),
-    )
-    .await;
-    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    // `logoUrl` is `format: uri`: an absolute https URI, which the schema
+    // validator does not assert and the community checks by hand.
+    for logo in [
+        "http://kernel.example/logo.svg",
+        "https://kernel.example/my logo.svg",
+        "https://kernel.example/logo\u{7}.svg",
+    ] {
+        let (status, body) = admin_rest(
+            &fix,
+            "PUT",
+            "/v1/community/branding",
+            Some(json!({ "logoUrl": logo })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{logo:?}: {body}");
+    }
 
     let (_did, doc) = signed_trust_task(JOIN_REQUEST_MANIFEST_0_2_TYPE, json!({})).await;
     let (status, body) = post_tt(&fix.router, doc).await;

--- a/vtc-service/tests/join_requests.rs
+++ b/vtc-service/tests/join_requests.rs
@@ -2042,8 +2042,8 @@ async fn vetting_statement_from(
     valid_from: chrono::DateTime<chrono::Utc>,
 ) -> Value {
     use vta_sdk::protocols::vetting::{
-        DeclaredRelationship, IDENTITY_VETTING_ENDORSEMENT_TYPE, IdentityVettingEndorsement,
-        VettingMethod,
+        IDENTITY_VETTING_ENDORSEMENT_TYPE, IdentityVettingEndorsement, VettingMethod,
+        VettingRelationship,
     };
     use vta_sdk::vetting::statement::{StatementDraft, sign_statement};
     let now = valid_from;
@@ -2056,12 +2056,12 @@ async fn vetting_statement_from(
                 endorsement_type: IDENTITY_VETTING_ENDORSEMENT_TYPE.into(),
                 community: vtc_service::test_support::TEST_VTC_DID.into(),
                 method: VettingMethod::Video,
-                document_classes: vec!["passport".into()],
-                claims_verified: vec!["name.legal".into()],
+                document_classes: vec!["passport".try_into().unwrap()],
+                claims_verified: vec!["name.legal".try_into().unwrap()],
                 liveness_confirmed: true,
                 identity_commitment: "zSameIdentity".into(),
                 card_digest_multibase: format!("zCard{n}"),
-                declared_relationship: DeclaredRelationship::None,
+                declared_relationship: VettingRelationship::None,
                 attestation_text_digest: None,
             },
             valid_from: now,
@@ -2346,7 +2346,7 @@ async fn only_an_admin_can_name_a_vetter() {
 /// `vta_sdk::vetting::eligibility`.
 #[tokio::test]
 async fn the_vetter_role_credential_is_revocable_and_verifies_for_an_applicant() {
-    use vta_sdk::protocols::vetting::VetterGrantBody;
+    use vta_sdk::protocols::vetting::vetters::grant::v0_1 as grant_wire;
     use vta_sdk::trust_task_proof::TrustTaskVmResolver;
     use vta_sdk::vetting::eligibility::{
         EligibilityExpectations, build_eligibility_vp, verify_eligibility_vp,
@@ -2399,11 +2399,10 @@ async fn the_vetter_role_credential_is_revocable_and_verifies_for_an_applicant()
     let grant = vtc_service::vetting::vetters::grant(
         &vtc.state,
         ADMIN_DID,
-        &VetterGrantBody {
-            member_did: vetter.clone(),
-            validity_seconds: Some(30 * 86_400),
-            ext: None,
-        },
+        &serde_json::from_value::<grant_wire::Payload>(
+            json!({ "memberDid": vetter, "validitySeconds": 30 * 86_400 }),
+        )
+        .unwrap(),
     )
     .await
     .expect("grant");
@@ -2848,12 +2847,12 @@ async fn unlisting_hides_a_profile_and_revoking_the_grant_deletes_it() {
 
 #[tokio::test]
 async fn an_older_profile_document_does_not_replace_a_newer_one() {
-    use vta_sdk::protocols::vetting::VetterProfileBody;
+    use vta_sdk::protocols::vetting::vetters::profile::v0_1::Payload as VetterProfile;
     use vtc_service::vetting::profiles::publish;
     let fix = build_fixture().await;
     let (carol, _) = did_key_secret([0x11; 32]);
     seed_vetter(&fix, &carol).await;
-    let body: VetterProfileBody = serde_json::from_value(carols_profile(true)).unwrap();
+    let body: VetterProfile = serde_json::from_value(carols_profile(true)).unwrap();
     let now = chrono::Utc::now();
 
     publish(&fix.state, &carol, &body, Some(now)).await.unwrap();

--- a/vtc-service/tests/trust_task_manifest.rs
+++ b/vtc-service/tests/trust_task_manifest.rs
@@ -430,45 +430,11 @@ const UNPUBLISHED_CANONICAL_OK: &[(&str, usize, &str)] = &[
         "VPC persona annotation (#1067) — bound ahead of its spec while \
          dtgwg-cred-spec#9 (how a VPC binds to an edge) is open upstream",
     ),
-    // Peer identity vetting — OpenVTC `docs/design/vetting-process.md`. Bound
-    // ahead of their specs by the same mechanism as the persona entry above:
-    // the payload types are in `vta_sdk::protocols::vetting`, and the specs are
-    // proposed upstream in trustoverip/dtgwg-trust-tasks-tf (stacked draft PRs
-    // `spec/vtc-join-manifest-vetting`, `spec/vetting-peer-tasks`,
-    // `spec/vetting-revoke-and-ceremony`). Each count goes to zero when the
-    // trust-tasks-rs release that serves it is taken here.
+    // Peer identity vetting (`vetting/*`, `vtc/vetting/*`) and join manifest
+    // 0.2 were bound ahead of their specs here, and went back to zero with
+    // trust-tasks-rs 0.20.4, which serves all nine and generates their wire
+    // types.
     //
-    // `vetting/{request,session,decline}/0.1` — the applicant↔vetter exchange.
-    // Top-level, not `spec/vtc/`: it runs between two people's agents, and no
-    // community service is party to it.
-    (
-        "https://trusttasks.org/spec/vetting/",
-        3,
-        "peer vetting request/session/decline — proposed in dtgwg-trust-tasks-tf \
-         (spec/vetting-peer-tasks)",
-    ),
-    // `vtc/vetting/revoke-statement/0.1` — a vetter withdrawing a statement
-    // from the community that relies on it (design §9.6).
-    // `vtc/vetting/vetters/grant/0.1` — an admin naming a vetter by issuing a
-    // revocable vetter role credential.
-    // `vtc/vetting/vetters/{profile,list,resend}/0.1` — the vetter registry: a
-    // vetter publishing a profile, anyone finding vetters, and a vetter asking
-    // for their grant credential again.
-    (
-        "https://trusttasks.org/spec/vtc/vetting/",
-        5,
-        "vetting statement revocation notice, vetter grant, and the vetter \
-         registry (profile, list, resend) — proposed in dtgwg-trust-tasks-tf \
-         (spec/vetting-revoke-and-ceremony, spec/vetting-vetters-grant)",
-    ),
-    // `vtc/join-requests/manifest/0.2` — 0.1 plus the per-criterion `vetting`
-    // requirements object and `requirementsDigest`.
-    (
-        "https://trusttasks.org/spec/vtc/join-requests/manifest/0.2",
-        1,
-        "join manifest with vetting requirements — proposed in dtgwg-trust-tasks-tf \
-         (spec/vtc-join-manifest-vetting)",
-    ),
     // Not a dispatchable task: the framework's error envelope is a *response*
     // type, deliberately absent from the task index, so `schema_for` will never
     // resolve it. This entry is permanent — the others are debt.

--- a/vtc-service/tests/vetting_journey.rs
+++ b/vtc-service/tests/vetting_journey.rs
@@ -46,10 +46,11 @@ use tower::ServiceExt;
 use uuid::Uuid;
 use vta_sdk::protocols::credential_exchange::{ISSUE as CREDENTIAL_ISSUE_TYPE, IssueBody};
 use vta_sdk::protocols::join_requests::JOIN_REQUEST_MANIFEST_0_2_TYPE;
+use vta_sdk::protocols::vetting::session::v0_1::VettingCardClaim;
 use vta_sdk::protocols::vetting::{
-    COMMUNITY_ROLE_ENDORSEMENT_TYPE, CardClaim, DeclaredRelationship,
-    IDENTITY_VETTING_ENDORSEMENT_TYPE, IdentityVettingEndorsement, VETTING_REVOKE_STATEMENT_TYPE,
-    VETTING_VETTER_LIST_TYPE, VETTING_VETTER_PROFILE_TYPE, VettingMethod,
+    COMMUNITY_ROLE_ENDORSEMENT_TYPE, IDENTITY_VETTING_ENDORSEMENT_TYPE, IdentityVettingEndorsement,
+    VETTING_REVOKE_STATEMENT_TYPE, VETTING_VETTER_LIST_TYPE, VETTING_VETTER_PROFILE_TYPE,
+    VettingMethod, VettingRelationship,
 };
 use vta_sdk::trust_task_proof::TrustTaskVmResolver;
 use vta_sdk::vetting::card::{
@@ -847,11 +848,15 @@ impl Community {
                 domain: self.did.clone(),
                 issued_at: Utc::now(),
                 validity: Duration::minutes(15),
-                claims: vec![CardClaim {
-                    claim_type: "name.legal".into(),
-                    value: json!(applicant.legal_name),
-                    provenance: "selfAsserted".into(),
-                }],
+                claims: vec![
+                    VettingCardClaim::try_from(
+                        VettingCardClaim::builder()
+                            .type_("name.legal")
+                            .value(json!(applicant.legal_name))
+                            .provenance("selfAsserted"),
+                    )
+                    .expect("a claim of the published shape"),
+                ],
                 identity_types: required.clone(),
                 salt: applicant.salt.clone(),
             },
@@ -884,12 +889,12 @@ impl Community {
                     endorsement_type: IDENTITY_VETTING_ENDORSEMENT_TYPE.into(),
                     community: self.did.clone(),
                     method,
-                    document_classes: vec!["passport".into()],
-                    claims_verified: required.clone(),
+                    document_classes: vec!["passport".try_into().unwrap()],
+                    claims_verified: vec!["name.legal".try_into().unwrap()],
                     liveness_confirmed: true,
-                    identity_commitment: checked.card().identity_commitment.clone(),
+                    identity_commitment: checked.card().identity_commitment.as_str().to_owned(),
                     card_digest_multibase: checked.digest_multibase().to_string(),
-                    declared_relationship: DeclaredRelationship::None,
+                    declared_relationship: VettingRelationship::None,
                     attestation_text_digest: None,
                 },
                 valid_from: now,

--- a/vtc-service/tests/vtc_client_live.rs
+++ b/vtc-service/tests/vtc_client_live.rs
@@ -109,12 +109,21 @@ async fn vetting_admin_verbs_round_trip() {
     .expect("connect");
 
     // Grant converges: the second call returns the first grant.
+    let grant = |payload: serde_json::Value| {
+        serde_json::from_value::<vtc_client::vetting::vetters::grant::v0_1::Payload>(payload)
+            .expect("a grant payload of the published shape")
+    };
     let first = client
-        .grant_vetter(&vetter, Some(30 * 86_400))
+        .grant_vetter(&grant(
+            serde_json::json!({ "memberDid": vetter, "validitySeconds": 30 * 86_400 }),
+        ))
         .await
         .unwrap();
     assert!(first.created);
-    let second = client.grant_vetter(&vetter, None).await.unwrap();
+    let second = client
+        .grant_vetter(&grant(serde_json::json!({ "memberDid": vetter })))
+        .await
+        .unwrap();
     assert!(!second.created);
     assert_eq!(second.grant.endorsement_id, first.grant.endorsement_id);
 
@@ -150,16 +159,23 @@ async fn vetting_admin_verbs_round_trip() {
         Err(vtc_client::VtcError::Http { status: 400, .. })
     ));
 
-    assert_eq!(client.branding().await.unwrap(), Default::default());
+    assert_eq!(
+        serde_json::to_value(client.branding().await.unwrap()).unwrap(),
+        serde_json::json!({})
+    );
     let branding = client
-        .set_branding(&vtc_client::join_requests::CommunityBranding {
-            display_name: Some("Kernel".into()),
-            accent_color: Some("#1A2B3C".into()),
-            ..Default::default()
-        })
+        .set_branding(
+            &serde_json::from_value(
+                serde_json::json!({ "displayName": "Kernel", "accentColor": "#1A2B3C" }),
+            )
+            .unwrap(),
+        )
         .await
         .unwrap();
-    assert_eq!(branding.accent_color.as_deref(), Some("#1a2b3c"));
+    assert_eq!(
+        branding.accent_color.as_deref().map(String::as_str),
+        Some("#1a2b3c")
+    );
 
     assert!(client.vetting_revocations().await.unwrap().is_empty());
 
@@ -167,8 +183,11 @@ async fn vetting_admin_verbs_round_trip() {
         .revoke_endorsement(&first.grant.endorsement_id)
         .await
         .unwrap();
-    assert_eq!(revoked.endorsement_id, first.grant.endorsement_id);
-    assert_eq!(revoked.revocation.credential_id, first.grant.credential_id);
+    assert_eq!(revoked.endorsement_id, first.grant.endorsement_id.as_str());
+    assert_eq!(
+        revoked.revocation.credential_id,
+        first.grant.credential_id.as_str()
+    );
     assert!(matches!(
         client.resend_vetter_grant(&vetter).await,
         Err(vtc_client::VtcError::Http { status: 404, .. })


### PR DESCRIPTION
## Why

The peer identity vetting Trust Tasks are specified in trustoverip/dtgwg-trust-tasks-tf, and `trust-tasks-codegen` generates Rust types for every one of them, published in `trust-tasks-rs` 0.20.4 under `trust_tasks_rs::specs`. The vetting stack (#1425–#1432) hand-wrote copies of those types instead — mainly `vta-sdk/src/protocols/vetting.rs`, ~2,450 lines and 39 public types — used by `vtc-service`, `vtc-client` and `cnm-cli`. The copies had already drifted from the specifications: a documented shape the schema refused, and an admin console calling a Trust Task URI that no route bound.

This makes the generated types the vetting wire layer. Nothing restates them, and a guard stops the next copy being written.

## What is generated, and what is still hand-written

**Generated, re-exported by `vta-sdk`:**

| Task | Where |
|---|---|
| `vetting/request/0.1` | `vta_sdk::protocols::vetting::request::v0_1` |
| `vetting/session/0.1` (with the Vetting Card) | `vta_sdk::protocols::vetting::session::v0_1` |
| `vetting/decline/0.1` | `vta_sdk::protocols::vetting::decline::v0_1` |
| `vtc/vetting/revoke-statement/0.1` | `vta_sdk::protocols::vetting::revoke_statement::v0_1` |
| `vtc/vetting/vetters/{grant,profile,list,resend}/0.1` | `vta_sdk::protocols::vetting::vetters::{grant,profile,list,resend}::v0_1` |
| `vtc/join-requests/manifest/{0.1,0.2}` | `vta_sdk::protocols::join_requests::manifest::{v0_1,v0_2}` |
| Requirements vocabulary (`VettingRequirements`, `VettingMethod`, `VettingRelationship`, `VettingDocumentation`, `ClaimType`) | `vta_sdk::protocols::vetting`, re-exported from manifest 0.2 |

Type URI constants (`VETTING_*_TYPE`, `JOIN_REQUEST_MANIFEST_*`) are the generated types' `TYPE_URI`.

**Hand-written, operating on the generated types:**

- `CheckShape` / `read_checked` (+ `read_request`, `read_requirements`, `read_branding`): validates against the schema each generated type embeds — read from the JSON **as received**, because some generated constructors normalise what they parse (a date written `2026-1-05` parses as `2026-01-05`) — then applies the rules the schema validator does not check: an event's `endDate` ≥ `startDate` and span ≤ 31 days, `eventTo` ≥ `eventFrom`, every `minByMethod` method in `acceptedMethods`, `joinDid` = document issuer — and `format: uri`. The schemas give an event's `url`, branding's `logoUrl` and the requirements' `governanceFrameworkUrl` `format: uri` with `^https://` and ≤ 2048, but the validator treats `format` as an annotation and does not assert it, so the layer enforces it by hand: an absolute https URI (RFC 3986) with a host, no whitespace or control characters. It runs on profile publish, listing responses, and branding PUT and storage, which refuse such a value; the admin console applies the same rule. Manifest 0.2 emission does not fail over branding: if stored branding breaks the rule (only a row written before the check could), the manifest is served without `branding` and a warning names the member at fault, not its value — branding is presentation only, and the manifest is what every applicant needs to join.
- `IdentityVettingEndorsement`, the Vetting Statement's credential body. It is `vetting/_shared/0.1/identity-vetting`, which is not a Trust Task, and the codegen does not generate shared definitions; its members now use the generated vocabulary types.
- Card and statement signing and verification, eligibility VP verification (`vetting/eligibility.rs`), credential status checks (`status.rs`), match codes, ticket URIs, requirements evaluation and digest.
- Extended error code constants (the codegen emits none).
- Admin REST bodies that are not Trust Tasks: `VetterGrantRow`/`VetterGrantListResponse` (`GET /v1/vetting/vetters`), `AutoGrantConfig`/`AutoGrantStatus` (`/v1/vetting/auto-grant`), `VettingRevocationRow` (`/v1/vetting/revocations`).

**REST routes that carry a task's body now take and return the generated types:** `POST /v1/vetting/vetters` (grant), `POST /v1/vetting/vetters/{memberDid}/resend`, `POST /v1/vetting/vetters/list`, `GET /v1/join-requests/manifest` (admin 0.2 and public 0.1). `GET`/`PUT /v1/community/branding` keeps its own route but its body *is* the manifest 0.2 `CommunityBranding` definition, so it takes the generated type rather than a copy — what an admin stores is exactly what the manifest publishes.

**OpenAPI.** Generated types are foreign, so `ToSchema` cannot be derived on them. The new `vta_sdk::openapi` module (feature `openapi`) provides transparent wrappers (`VetterGrant01Payload`, `JoinManifest02Response`, …) whose schemas are rendered from the JSON Schema the generated type embeds. Components are named after the specification — `VtcVettingVettersListV0_1ListedVetter` — so two specs' `VetterEvent`s cannot collide. `admin-ui/openapi.json` and `wire.ts` are regenerated; `wire-types.ts` aliases the new names, and the console's hand-written `VettingRequirements` interface is replaced by the alias. (utoipa's model has no fields for `dependentSchemas`, `dependentRequired`, `not` or `propertyNames`; those are enforced at runtime.)

## trust-tasks bump

All five crates move to **0.20.4** (`trust-tasks-rs`, `-https`, `-didcomm`, `-proof`, `-capability-client`), all published on crates.io. `Cargo.lock` updated; `check-lockfile-self-pins.sh`, `check-workspace-version-reqs.py`, `check-nitro-copies-every-member.py` and `check-authz-context-types.sh` pass. The workspace dependency already enables `validate` and `all-specs`, so no feature change was needed. `trust-tasks-rs` becomes a **required** dependency of `vta-sdk`, because the always-compiled protocol modules re-export it. No crate `version =` was edited.

## Wire divergences (the specification wins)

| Member | Before | Now | Who is affected |
|---|---|---|---|
| every `ext` | any JSON value accepted (`{}`, `{"x":1}`) | an object with ≥ 1 member whose keys are reverse-DNS namespaces (SPEC §4.5.1) | any producer of these tasks, and branding `ext` |
| `vetting/request` `introduction` | any JSON value | a JSON object; a ticket and an introduction (even `{}`) together are refused | applicants and vetters (openvtc) |
| `vetting/request` `ticket` | extra members inside `{code}` / `{ticketId, secret}` ignored | refused (`additionalProperties: false`) | applicants |
| `vetting/request` `languages` | omitted when empty | sent as `[]` when set to an empty list | applicant producers |
| `vetting/request#response` `acceptsDocumentation` | `[]` accepted, omitted when empty | `minItems: 1`, unique | vetters' clients |
| `vetting/request#response` `eligibilityVp` | any JSON value | the published `EligibilityPresentation` shape (`@context`, `type`, `holder`, `verifiableCredential`, `nonce`, `domain`, `authentication` proof) | vetters' clients |
| `vetting/session` `requiredClaims`/`optionalClaims` | any strings (portrait refused) | `ClaimType` pattern, unique, portrait refused; `optionalClaims` sent as `[]` if set empty | vetters' clients |
| Vetting Card `id` | any string | `urn:uuid:` + a UUID | applicants' clients |
| Vetting Card claim `type` | any string | `ClaimType` pattern, ≤ 128 | applicants' clients |
| Vetting Card `cardVersion` | `u32` (0 accepted) | integer ≥ 1 | none in practice (the SDK writes 1) |
| Vetting Card `proof` | optional in the type | required by the schema (verification already required it) | none |
| Statement endorsement `documentClasses` / `claimsVerified` | duplicates accepted, `none` accepted, claims any string | unique; `none` never listed (the shared definition: no document is the empty list); claims are `ClaimType` | vetters signing; the community stops counting a statement that breaks this |
| `vtc/vetting/revoke-statement` `statementDigestMultibase` | any string (the community decoded it later) | `DigestMultibase` pattern, ≥ 16 chars | vetters |
| manifest 0.2 `vetting.independence` | always emitted as `{"requireConsistentIdentityCommitment": false}` when absent | emitted only as registered | **every `requirementsDigest` of a criterion without explicit independence changes once**; applicants who recorded one mid-application see it change |
| manifest 0.2 `vetting.acceptedDocumentClasses` | `[]` accepted | `minItems: 1`, unique | community admins |
| manifest 0.2 `vetting.acceptedMethods` | duplicates accepted | unique | community admins |
| manifest 0.2 `vetting.version` | leading zeros accepted (`01.1`) | `(0\|[1-9][0-9]*)\.(0\|[1-9][0-9]*)` | community admins |
| manifest 0.2 `vetting.requiredClaims`/`optionalClaims` | any strings | `ClaimType` pattern, unique | community admins |
| manifest criterion `id` / `description` | unbounded | 1–128 / ≤ 1024 (manifest 0.2); registering a criterion the manifest cannot publish is refused | community admins |
| `vtc/vetting/vetters/list#response` `vetters` | no cap | ≤ 100 (the listing never exceeded it) | none |
| `listing` cursors | bound to the old serialisation of the filters | bound to the generated type's; a cursor issued before the upgrade is refused once | anyone paging a listing across the upgrade |
| OpenAPI component names | `VetterGrantBody`, `ListedVetter`, `CommunityBranding`, `JoinRequestManifestResponseBody`, … | spec-named (`VtcVettingVettersGrantV0_1Payload`, …) | generated OpenAPI clients (the admin console is updated) |

Unchanged on the wire: member names and casing, event dates (still exactly `YYYY-MM-DD` as received), URL members (an event `url`, `logoUrl` and `governanceFrameworkUrl` are still refused unless they are an absolute https URI of at most 2048 characters with no whitespace or control characters — the schemas' `format: uri`, which the validator does not assert, is checked by hand), grant validity bounds, listing bounds and order, admin REST status codes (still 400 for a body that breaks its schema; `malformedRequest` over Trust Tasks).

## `vta-sdk` public API changes a consumer (openvtc) must make

Generated structs are `#[non_exhaustive]`: construct with `X::builder()` + `X::try_from(builder)` or by deserializing; constrained strings are newtypes (`TryFrom<&str>`, deref to `String`). Import `vta_sdk::protocols::vetting::CheckShape` where `check_shape()` is called.

**`vta_sdk::protocols::vetting`**

| Old | New |
|---|---|
| `VettingRequestBody` | `request::v0_1::Payload` |
| `TicketPresentation::Scanned { ticket_id, secret }` / `::Code { code }` | `request::v0_1::Ticket::QrTicket(QrTicket { ticket_id, secret })` / `::ShortCodeTicket(ShortCodeTicket { code })` |
| `VettingRequestAcceptedBody` | `request::v0_1::Response` |
| `VettingSessionBody` / `VettingSessionResponseBody` | `session::v0_1::Payload` / `session::v0_1::Response` |
| `VettingCard` (`types`, `proof: Option<Value>`) | `session::v0_1::VettingCard` (`type_`, `proof: DataIntegrityProof`) |
| `CardClaim { claim_type, value, provenance }` | `session::v0_1::VettingCardClaim { type_, value, provenance }` |
| `VettingDeclineBody`, `DeclineCode` | `decline::v0_1::Payload`, `decline::v0_1::PayloadCode` |
| `RevokeStatementBody`, `RevocationReason`, `RevokeStatementResponseBody` | `revoke_statement::v0_1::{Payload, PayloadReason, Response}` |
| `VetterGrantBody`, `VetterGrantResponseBody` | `vetters::grant::v0_1::{Payload, Response}` (`validity_seconds: Option<i64>`) |
| `VetterProfileBody`, `VetterProfileResponseBody`, `VetterLocation`, `VetterEvent` | `vetters::profile::v0_1::{Payload, Response, VetterLocation, VetterEvent}` |
| `VetterListBody`, `VetterListResponseBody`, `ListedVetter` | `vetters::list::v0_1::{Payload, Response, ListedVetter}` |
| `VetterListBody::has_event_filter()` | `has_event_filter(&body)` |
| `VetterResendBody`, `VetterResendResponseBody` | `vetters::resend::v0_1::{Payload, Response}` |
| `VettingRequirements`, `EligibleVetters`, `Independence`, `InvitationRequirement` | `VettingRequirements`, `VettingRequirementsEligibleVetters`, `VettingRequirementsIndependence` (members now `Option`s), `VettingRequirementsInvitation` |
| `VettingRequirements::validate()`, `InvalidRequirements` | `CheckShape::check_shape()` or `read_requirements(&json)`; `ShapeError` |
| `VettingRequirements::max_statement_age()` | `max_statement_age(&requirements)` |
| `VettingMethod::as_str()` / `::parse()` | `Display` / `FromStr` (generated enum, same path) |
| `DeclaredRelationship` | `VettingRelationship` |
| `<type>::check_shape()` (inherent) | `CheckShape::check_shape()` (trait) |
| `VettingRequestBody::check_shape(issuer)` | `check_request(&payload, issuer)` or `read_request(&json, issuer)` |
| `ShapeError::TicketAndIntroduction` (enum was `Copy`) | `ShapeError::Schema(String)`; enum no longer `Copy` |
| `IdentityVettingEndorsement` `document_classes: Vec<String>`, `claims_verified: Vec<String>`, `declared_relationship: DeclaredRelationship` | `Vec<VettingDocumentation>`, `Vec<ClaimType>`, `VettingRelationship` |
| `VETTING_CARD_TYPES: [&str; 3]` | `[session::v0_1::VettingCardTypeItem; 3]` |
| `DEFAULT_VETTER_LIST_LIMIT: u32` | `u64` |
| `MAX_VETTER_{NAME_CHARS,LANGUAGES,METHODS,ACCEPTED_DOCUMENTATION,AVAILABILITY_CHARS,CONTACT_HINT_CHARS,EVENTS,EVENT_NAME_CHARS}`, `MAX_VETTING_URL_CHARS`, `MAX_VETTER_LIST_LIMIT`, `MAX_VETTER_LIST_CURSOR_CHARS` | removed — the schemas carry these bounds |
| `VetterProfileSummary.methods: Vec<VettingMethod>` | `Vec<vetters::profile::v0_1::VettingMethod>` |
| — | new: `read_checked`, `read_request`, `read_requirements`, `read_branding`, `CheckShape`, `check_request`, `has_event_filter`, `max_statement_age`; re-exports `ClaimType`, `VettingDocumentation` |

**`vta_sdk::protocols::join_requests`** (feature `didcomm`, as before)

| Old | New |
|---|---|
| `JoinRequestManifestResponseBody` | `manifest::v0_1::Response` (0.1) / `manifest::v0_2::Response` (0.2) |
| `ManifestCriterion` (`presentation_definition: Value`) | `manifest::v0_1::ResponseCriteriaItem` / `manifest::v0_2::Criterion` (`presentation_definition: serde_json::Map`) |
| `CommunityBranding`, `::is_empty()`, `::check_shape()`, `MAX_BRANDING_*` | `manifest::v0_2::CommunityBranding`; `read_branding` / `CheckShape`; bounds in the schema |

**`vta_sdk::vetting`** (feature `vetting`)

| Old | New |
|---|---|
| `card::CardDraft.claims: Vec<CardClaim>`; `identity_commitment(salt, &[CardClaim], …)` | `Vec<VettingCardClaim>`; `&[VettingCardClaim]` |
| `card::VerifiedVettingCard::card() -> &VettingCard`, `::claim() -> Option<&CardClaim>` | `&session::v0_1::VettingCard`, `Option<&VettingCardClaim>` |
| card `id` any string | must be `urn:uuid:<uuid>` |
| `requirements::StatementFacts.{method, declared_relationship}`, `Evaluation.by_relationship`, `Need::Method` | the generated `VettingMethod` / `VettingRelationship` |
| `ticket_uri::TicketUri.presentation: TicketPresentation` (`TicketUri: PartialEq + Eq`) | `request::v0_1::Ticket` (no `PartialEq`/`Eq`) |
| `ticket_uri::encode() -> String` | `-> Result<String, VettingError>` |

**`vta_sdk::openapi`** (new, feature `openapi`): the documentation wrappers above.

**`vtc-client`**

| Old | New |
|---|---|
| `grant_vetter(member_did, validity_seconds)` | `grant_vetter(&vetting::vetters::grant::v0_1::Payload)` |
| `VetterGrant.grant: VetterGrantResponseBody` (`VetterGrant: PartialEq`) | `vetting::vetters::grant::v0_1::Response` (no `PartialEq`) |
| `resend_vetter_grant() -> VetterResendResponseBody` | `-> vetting::vetters::resend::v0_1::Response` |
| `branding()` / `set_branding()` on `join_requests::CommunityBranding` | `join_requests::manifest::v0_2::CommunityBranding` |

## The guard

`vta-sdk/tests/generated_wire_types_census.rs` runs in the workspace test job. It reads every `Serialize`/`Deserialize` struct and enum in every workspace member's production source (with `syn`), and fails when a type's doc summary names a Trust Task as its payload, request, response or body **and** `trust_tasks_rs::schema_index` has a generated module for that task. It carries a baseline of 69 pre-existing hand-written types (acl, policy, config, keys, audit, rooms, vault, several VTC admin envelopes) that **only shrinks**: an entry is removed when its type is migrated, the count is asserted, and a stale entry fails.

The workspace guidelines gain the rule: Trust Task wire types come from `trust_tasks_rs::specs`; never hand-write a payload or response type for a task in the registry; keep behaviour and the rules a schema cannot state as checks over the generated types; read received JSON against the schema before parsing; specification changes land in dtgwg-trust-tasks-tf first and arrive through a `trust-tasks-rs` bump. `docs/03-vtc/vetting.md` says where the wire types come from.

The conformance sweep gains witnesses for manifest 0.2 and the five `vtc/vetting/*` tasks the registry now serves, and `trust_task_manifest`'s unpublished-URI allowance for the nine vetting URIs goes to zero.

## Test evidence

Run on this branch, rebased onto `main` at 500bf059:

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0, no warnings |
| `cargo test --workspace --exclude vtc-service --exclude vtc-client --no-fail-fast` | **4209 passed, 0 failed**, 50 ignored (118 test binaries), including the new census 3/3 |
| `cargo test -p vtc-service -p vtc-client --no-fail-fast` (with `VTC_SKIP_ADMIN_UI_BUILD=1`) | **1607 passed, 0 failed**, 1 ignored: units 1030 (3 binaries), integration 577 (55 binaries) |
| the same, with the real admin UI build: `admin_ui` unit tests / `routing_modes` | 8/8, 9/9 |
| `cargo test -p vta-sdk --lib --features vetting,openapi,didcomm` | 415 passed, 0 failed |
| vetting round-trips: `vetting_journey` / `join_requests` / `join_didcomm` / `vtc_client_live` | 2/2, 79/79, 3/3, 6/6 |
| `trust_task_manifest` / `openapi_snapshot` / `openapi_response_census` | 8/8, 4/4, 6/6 (the conformance sweep runs in the vtc-service units) |
| admin UI: `npm run lint` / `npm test` / `npm run build` | ok / 60 passed (9 files) / ok; `package-lock.json` unchanged |
| `check-lockfile-self-pins.sh`, `check-workspace-version-reqs.py`, `check-nitro-copies-every-member.py`, `check-authz-context-types.sh` | all exit 0 |

After the last two commits (`format: uri` enforced by hand; manifest 0.2 served without branding that breaks it), re-run on the final head:

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets -- -D warnings` / the four guard scripts | clean / exit 0, no warnings / all exit 0 |
| `cargo test -p vta-sdk --lib --features vetting,openapi,didcomm` | 417 passed, 0 failed (2 new: `a_format_uri_member_is_an_absolute_https_uri`, `a_listed_event_url_is_an_absolute_https_uri`) |
| `cargo test -p vtc-service --lib` | 1012 passed, 0 failed, 1 ignored (new: `branding_the_manifest_cannot_carry_is_omitted_and_the_manifest_still_served`, `the_warning_names_the_member_at_fault_not_its_value`) |
| `cargo test -p vtc-service --test join_requests` / `--test join_didcomm` / `--test trust_task_manifest` | 80 / 3 / 8 passed, 0 failed (new: `a_profile_whose_event_url_is_not_an_absolute_https_uri_is_malformed`; branding PUT cases added) |
| `cargo test -p vtc-client -p cnm-cli` | 66 passed, 0 failed |
| admin UI: `npm run lint` / `npm test` / `npm run build` | ok / 77 passed / ok |

With the UI build skipped, the expected `admin_ui::tests` and `routing_modes::path_mode_admin_*` failures did not occur here, because the build directory already held a built console bundle.

## Not done

- **69 other hand-written types** for tasks that have generated modules remain, recorded in the census baseline. Migrating them is separate work.
- **`IdentityVettingEndorsement` is still hand-written**: `vetting/_shared/0.1/identity-vetting` is not a Trust Task and the codegen generates no shared definitions. Generating `_shared` definitions upstream would let it go too.
- **Extended error codes** stay hand-written constants; the codegen does not emit them.
- **The admin console's form checks** (`validateRequirements`, `validateBranding`, `buildListBody`) still restate schema rules in TypeScript for inline feedback. The daemon remains the authority; they are not generated.
- **The guard reads doc summaries**: a wire type whose summary does not name its task is invisible to it. The guidelines say to name it.
- **The OpenAPI rendering** omits `dependentSchemas`, `dependentRequired`, `not` and `propertyNames`, which utoipa cannot represent.
- **openvtc** is not updated here; the table above is what it needs.
