### PR TITLE
ci: pin every action to a commit SHA and drop CI to least privilege

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,13 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    # A release is at its most dangerous in the days before anyone has looked
+    # at it: a hijacked maintainer account or a retagged release is noticed by
+    # the ecosystem within about a week, and this makes Dependabot wait that
+    # week before proposing it. SECURITY updates are NOT subject to the
+    # cooldown, so an advisory still arrives the day it lands.
+    cooldown:
+      default-days: 7
     # Enough headroom for a normal week without burying the queue. A security
     # advisory is not subject to this cap.
     open-pull-requests-limit: 5
@@ -51,13 +58,33 @@ updates:
       - dependency-name: "vtc-*"
 
   # ── GitHub Actions ────────────────────────────────────────────────────
-  # `dtolnay/rust-toolchain@master` and `taiki-e/install-action@cargo-semver-checks`
-  # are branch/tag refs Dependabot cannot version, and it leaves them alone.
-  # The rest are pinned majors it can move.
+  # Every `uses:` in this repo is a full 40-hex commit SHA with the version in
+  # a trailing `# vX.Y.Z` comment. That is the form Dependabot understands: it
+  # moves the SHA and rewrites the comment, so pinning costs nothing in
+  # freshness.
+  #
+  # The two refs this comment used to excuse are gone. `dtolnay/rust-toolchain`
+  # published no tags at all — `@stable` and `@master` are branches — so it was
+  # replaced with the `rustup` lines it was running for us, and
+  # `taiki-e/install-action@cargo-semver-checks` (a tool-named tag, re-pointed
+  # on every release of that tool) is now the pinned `v2` action with
+  # `with: tool:`. Nothing here is unversionable any more.
+  #
+  # Weekly, not monthly: a pinned action only moves when something here moves
+  # it, and a month of latency on a fixed action bug is a month of running the
+  # bug. The grouping below still makes it one pull request.
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+      day: monday
+    # A release is at its most dangerous in the days before anyone has looked
+    # at it: a hijacked maintainer account or a retagged release is noticed by
+    # the ecosystem within about a week, and this makes Dependabot wait that
+    # week before proposing it. SECURITY updates are NOT subject to the
+    # cooldown, so an advisory still arrives the day it lands.
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "ci(deps)"
     groups:
@@ -73,5 +100,46 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    # A release is at its most dangerous in the days before anyone has looked
+    # at it: a hijacked maintainer account or a retagged release is noticed by
+    # the ecosystem within about a week, and this makes Dependabot wait that
+    # week before proposing it. SECURITY updates are NOT subject to the
+    # cooldown, so an advisory still arrives the day it lands.
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(docker)"
+
+  # ── Rust: the Nitro parent-instance proxy ─────────────────────────────
+  # `deploy/nitro/enclave-proxy` is its OWN workspace with its own
+  # `Cargo.lock`, and the root `Cargo.toml` lists it under `exclude` because
+  # tokio-vsock is Linux-only and it therefore cannot build on a macOS
+  # developer machine. The `/` entry above reads the root manifest and so has
+  # never seen it: until this entry, nothing proposed a bump for the process
+  # that terminates TLS in front of the enclave, and its lockfile was updated
+  # only when someone remembered.
+  #
+  # Its manifest asks for versions to be kept aligned with the workspace by
+  # hand. That is still true — this only makes the drift visible as a pull
+  # request instead of leaving it to be discovered.
+  - package-ecosystem: cargo
+    directory: /deploy/nitro/enclave-proxy
+    schedule:
+      interval: weekly
+      day: monday
+    # A release is at its most dangerous in the days before anyone has looked
+    # at it: a hijacked maintainer account or a retagged release is noticed by
+    # the ecosystem within about a week, and this makes Dependabot wait that
+    # week before proposing it. SECURITY updates are NOT subject to the
+    # cooldown, so an advisory still arrives the day it lands.
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: scope
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,6 +715,14 @@ jobs:
             echo "::error::scratch or log files are tracked at the repo root"
             exit 1
           fi
+      # Third cheap whole-tree invariant sharing this job, and the one with the
+      # sharpest consequence if it slips: an unpinned `uses:` lets a third-party
+      # action change under a job that holds this repo's crates.io publishing
+      # identity. It lives here, beside the other two, so that pinning does not
+      # depend on a new required status check being configured before it is
+      # enforced. See the script header.
+      - name: Workflow actions are pinned to commit SHAs
+        run: bash scripts/check-workflow-action-pins.sh
 
   lockfile-resolves:
     # The sibling of the job above, and the same misattribution failure it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install system dependencies
         run: |
@@ -95,9 +95,23 @@ jobs:
           echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
-      - uses: dtolnay/rust-toolchain@stable
+      # The toolchain comes from the runner image's rustup rather than from
+      # dtolnay/rust-toolchain. That action publishes no release tags: every ref
+      # it offers (`@stable`, `@master`) is a BRANCH, so there is no immutable
+      # ref to pin and nothing for Dependabot to bump afterwards — and the tip
+      # does move under us. The CI log captured in #1239 shows `@stable`
+      # resolving to 4360b525 on 2026-09-02; by 2026-09-11 it was 6bed0761.
+      # Every Check, Test, Clippy and *publish* job in between ran whatever that
+      # branch happened to point at, unreviewed.
+      #
+      # rustup ships on every hosted runner, so the lines below are the whole of
+      # what the action was doing here.
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # `target/` is deliberately NOT cached. Every crate in this
           # workspace is a **path** dependency, so a source-only change does not
@@ -135,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # `cargo test --workspace` builds a test binary for every crate with
       # full debuginfo, and the total (target/ plus the linker's scratch)
@@ -157,9 +171,12 @@ jobs:
       - name: Install system dependencies
         run: bash scripts/install-build-deps.sh
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # `target/` is deliberately NOT cached. Every crate in this
           # workspace is a **path** dependency, so a source-only change does not
@@ -194,7 +211,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # `cargo test --workspace` builds a test binary for every crate with
       # full debuginfo, and the total (target/ plus the linker's scratch)
@@ -216,9 +233,12 @@ jobs:
       - name: Install system dependencies
         run: bash scripts/install-build-deps.sh
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # `target/` is deliberately NOT cached. Every crate in this
           # workspace is a **path** dependency, so a source-only change does not
@@ -290,7 +310,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install system dependencies
         run: |
@@ -330,11 +350,13 @@ jobs:
           echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update \
+            --component clippy
+          rustup default stable
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # `target/` is deliberately NOT cached. Every crate in this
           # workspace is a **path** dependency, so a source-only change does not
@@ -364,11 +386,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update \
+            --component rustfmt
+          rustup default stable
 
       - run: cargo fmt --all -- --check
 
@@ -381,7 +405,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Same reclaim as the Test job, and for the same reason: this job
       # also links the whole workspace. It ran out of disk mid-`cargo
@@ -437,11 +461,14 @@ jobs:
           echo "msrv=$msrv" >> "$GITHUB_OUTPUT"
           echo "Workspace MSRV: $msrv"
 
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ steps.msrv.outputs.msrv }}
+      - name: Install the MSRV toolchain
+        env:
+          MSRV: ${{ steps.msrv.outputs.msrv }}
+        run: |
+          rustup toolchain install "$MSRV" --profile minimal --no-self-update
+          rustup default "$MSRV"
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # `target/` is deliberately NOT cached here any more.
           #
@@ -482,8 +509,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check advisories bans sources licenses
 
@@ -518,14 +545,19 @@ jobs:
     timeout-minutes: 45
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Install system dependencies
         run: bash scripts/install-build-deps.sh
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cargo-semver-checks
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+      - uses: taiki-e/install-action@9534c84618278caac52cb373bb164ed464dbd8af # v2.87.11
+        with:
+          tool: cargo-semver-checks
 
       # Everything this job knows about its own failure modes now lives in
       # scripts/semver-report.sh, including the exclusion list and the reasons
@@ -565,7 +597,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Same system packages as the report job, from the same script. Omitting
       # this is what broke the guard's first real run: rustdoc could not build
       # `vta-cli-common` (libdbus-sys -> pkg_config), and a failed baseline build
@@ -573,8 +605,13 @@ jobs:
       # rather than a missing build dependency on the runner.
       - name: Install system dependencies
         run: bash scripts/install-build-deps.sh
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cargo-semver-checks
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+      - uses: taiki-e/install-action@9534c84618278caac52cb373bb164ed464dbd8af # v2.87.11
+        with:
+          tool: cargo-semver-checks
       - name: Check the proposed versions cover their API changes
         env:
           SEMVER_MODE: enforce
@@ -598,7 +635,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Lockfile self-pin guard
         run: bash scripts/check-lockfile-self-pins.sh
       # Same shape of invariant, same reason to check it early: a whole-tree property
@@ -630,7 +667,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Authorization-context type uniqueness guard
         run: bash scripts/check-authz-context-types.sh
       # Unrelated to authz, but just as cheap: nothing at the repo root should be
@@ -682,8 +719,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: Cargo.lock satisfies every workspace manifest
         run: |
           if cargo metadata --locked --format-version 1 > /dev/null; then
@@ -717,7 +757,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install system dependencies
         run: |
@@ -757,9 +797,12 @@ jobs:
           echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # `target/` is deliberately NOT cached. Every crate in this
           # workspace is a **path** dependency, so a source-only change does not
@@ -969,11 +1012,14 @@ jobs:
       vta_tests: ${{ steps.vta_tests.outputs.run }}
       vtc_tests: ${{ steps.vtc_tests.outputs.run }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # The diff is the whole input; a shallow clone has no base to diff from.
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - id: mobile
         run: bash scripts/ci-affects.sh vta-mobile-core
       - id: enclave
@@ -996,7 +1042,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install system dependencies
         run: |
@@ -1036,9 +1082,12 @@ jobs:
           echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # `target/` is deliberately NOT cached. Every crate in this
           # workspace is a **path** dependency, so a source-only change does not
@@ -1078,17 +1127,19 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim,aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update \
+            --target aarch64-apple-ios,aarch64-apple-ios-sim,aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
+          rustup default stable
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@9534c84618278caac52cb373bb164ed464dbd8af # v2.87.11
         with:
           tool: cargo-ndk
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # `target/` is deliberately NOT cached. Every crate in this
           # workspace is a **path** dependency, so a source-only change does not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+# Read-only, and every job below inherits it: nothing in CI writes to the
+# repository. Without this block a workflow gets the repository's DEFAULT
+# token, which is write-all — the captured log in #1239 shows an ordinary
+# same-repo PR run holding `Contents: write, Actions: write, Checks: write,
+# Deployments: write, …`. A fork PR was always read-only; push, `merge_group`
+# and same-repo PR runs were not.
+permissions:
+  contents: read
+
 # One live run per ref. Pushing a fixup to an open PR used to leave the
 # superseded run executing and racing the new one for the same runner pool;
 # a superseded PR run tells you nothing worth waiting for.
@@ -55,7 +64,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # Nothing in this workflow pushes, so the checkout keeps no credentials.
+      # By default actions/checkout leaves the job's token in
+      # `.git/config`, where every later step — including a build script and
+      # every third-party action in the job — can read it.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         run: |
@@ -150,6 +165,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # `cargo test --workspace` builds a test binary for every crate with
       # full debuginfo, and the total (target/ plus the linker's scratch)
@@ -212,6 +229,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # `cargo test --workspace` builds a test binary for every crate with
       # full debuginfo, and the total (target/ plus the linker's scratch)
@@ -311,6 +330,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         run: |
@@ -387,6 +408,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install the Rust toolchain
         run: |
@@ -406,6 +429,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Same reclaim as the Test job, and for the same reason: this job
       # also links the whole workspace. It ran out of disk mid-`cargo
@@ -510,6 +535,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check advisories bans sources licenses
@@ -548,6 +575,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install system dependencies
         run: bash scripts/install-build-deps.sh
@@ -598,6 +626,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # Same system packages as the report job, from the same script. Omitting
       # this is what broke the guard's first real run: rustdoc could not build
       # `vta-cli-common` (libdbus-sys -> pkg_config), and a failed baseline build
@@ -636,6 +666,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Lockfile self-pin guard
         run: bash scripts/check-lockfile-self-pins.sh
       # Same shape of invariant, same reason to check it early: a whole-tree property
@@ -668,6 +700,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Authorization-context type uniqueness guard
         run: bash scripts/check-authz-context-types.sh
       # Unrelated to authz, but just as cheap: nothing at the repo root should be
@@ -720,6 +754,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install the Rust toolchain
         run: |
           rustup toolchain install stable --profile minimal --no-self-update
@@ -758,6 +794,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         run: |
@@ -1016,6 +1054,7 @@ jobs:
         with:
           # The diff is the whole input; a shallow clone has no base to diff from.
           fetch-depth: 0
+          persist-credentials: false
       - name: Install the Rust toolchain
         run: |
           rustup toolchain install stable --profile minimal --no-self-update
@@ -1043,6 +1082,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         run: |
@@ -1128,6 +1169,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install the Rust toolchain
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,9 +65,9 @@ jobs:
             # a user boundary. Asserting non-root here would be wrong.
             expect_non_root: false
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       # Deliberately NO build cache — neither `type=gha` nor actions/cache.
       # GitHub's Actions cache is a single ~10 GB allowance shared across the
@@ -77,7 +77,7 @@ jobs:
       # the runner out of disk. Path-filtering this job is the cheaper lever —
       # it makes the build rare rather than making it fast.
       - name: Build image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ${{ matrix.file }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,12 @@ on:
       - "Cargo.lock"
       - ".github/workflows/docker.yml"
 
+# Read-only: both images are built with `push: false` and this workflow logs
+# in to no registry, so reading the tree is all it needs. Without a block it
+# inherits the repository default, which is write-all.
+permissions:
+  contents: read
+
 jobs:
   image:
     name: Docker image (${{ matrix.name }})
@@ -65,7 +71,13 @@ jobs:
             # a user boundary. Asserting non-root here would be wrong.
             expect_non_root: false
     steps:
+      # Nothing in this workflow pushes, so the checkout keeps no credentials.
+      # By default actions/checkout leaves the job's token in
+      # `.git/config`, where every later step — including a build script and
+      # every third-party action in the job — can read it.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 

--- a/.github/workflows/join-didcomm-soak.yml
+++ b/.github/workflows/join-didcomm-soak.yml
@@ -61,7 +61,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
+      # Nothing in this workflow pushes, so the checkout keeps no credentials.
+      # By default actions/checkout leaves the job's token in
+      # `.git/config`, where every later step — including a build script and
+      # every third-party action in the job — can read it.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config

--- a/.github/workflows/join-didcomm-soak.yml
+++ b/.github/workflows/join-didcomm-soak.yml
@@ -61,14 +61,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
 
-      - uses: dtolnay/rust-toolchain@stable
+      # rustup from the runner image, not dtolnay/rust-toolchain: that action
+      # offers only branch refs, so there is nothing immutable to pin. See the
+      # longer note in ci.yml.
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       # Built once, then executed in a loop: `cargo test` would re-check the
       # workspace on every iteration and most of the wall-clock would be cargo,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
       # See docs/05-design-notes/trusted-publishing.md.
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history + tags: release-plz diffs each crate against the
           # commit its last release was tagged at.
@@ -119,7 +119,13 @@ jobs:
           echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
-      - uses: dtolnay/rust-toolchain@stable
+      # rustup from the runner image, not dtolnay/rust-toolchain: that action
+      # offers only branch refs, so there is nothing immutable to pin. See the
+      # longer note in ci.yml.
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       # Checked before the Trusted Publishing exchange below, so a malformed
       # `package` fails the run before a registry token exists. The value is
@@ -135,7 +141,7 @@ jobs:
             || { echo "::error::package must be a crate name"; exit 1; }
 
       - name: Authenticate to crates.io (Trusted Publishing)
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
 
       # Single-crate recovery. Deliberately `cargo publish` rather than
@@ -162,7 +168,7 @@ jobs:
         # moving major tag, so `@v0` resolves to nothing and the job fails at
         # "Set up job" before running a step. (actions/checkout@v6 works
         # because that repo does publish v6 — the convention is not universal.)
-        uses: release-plz/action@v0.5.136
+        uses: release-plz/action@a80d79efe0a195618acb02a4089d55fe74d2505f # v0.5.136
         with:
           command: release
         env:
@@ -186,7 +192,7 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -229,7 +235,10 @@ jobs:
           echo "::error::apt-get failed after the shipped index and 3 bounded refreshes"
           exit 1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
 
       # release-plz compares each crate's public API against its published
       # version and forces a compatibility-breaking bump when it actually
@@ -238,14 +247,16 @@ jobs:
       # guessing from commit messages — which is the failure this exists to
       # prevent, and it is only a warning, so nothing goes red.
       - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@cargo-semver-checks
+        uses: taiki-e/install-action@9534c84618278caac52cb373bb164ed464dbd8af # v2.87.11
+        with:
+          tool: cargo-semver-checks
 
       - name: Run release-plz
         # Pinned to a full version: release-plz/action does NOT publish a
         # moving major tag, so `@v0` resolves to nothing and the job fails at
         # "Set up job" before running a step. (actions/checkout@v6 works
         # because that repo does publish v6 — the convention is not universal.)
-        uses: release-plz/action@v0.5.136
+        uses: release-plz/action@a80d79efe0a195618acb02a4089d55fe74d2505f # v0.5.136
         with:
           command: release-pr
         env:

--- a/.github/workflows/release-mobile-ios.yml
+++ b/.github/workflows/release-mobile-ios.yml
@@ -23,13 +23,18 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+      # rustup from the runner image, not dtolnay/rust-toolchain: that action
+      # offers only branch refs, so there is nothing immutable to pin. See the
+      # longer note in ci.yml.
+      - name: Install the Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update \
+            --target aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+          rustup default stable
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release-mobile-ios.yml
+++ b/.github/workflows/release-mobile-ios.yml
@@ -14,16 +14,29 @@ on:
     tags: ["vta-mobile-core-v*"]
   workflow_dispatch: {}
 
+# Read-only by default. The token that can create a Release is held by the
+# `publish` job alone — see the note there.
 permissions:
-  contents: write # create the Release + upload assets
+  contents: read
 
 jobs:
-  ios-xcframework:
-    name: Package + publish iOS xcframework
+  build:
+    # Compiles three Apple targets and runs a packaging script, so this is the
+    # job with the large attack surface: a whole Rust dependency graph plus
+    # build scripts. It is therefore the job that must NOT be able to write to
+    # the repository. It was: `contents: write` used to sit at the top level and
+    # this was the only job, so every crate's build script ran beside a token
+    # that could create a Release and move a tag.
+    name: Package iOS xcframework
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
+      # Nothing in this job pushes, so the checkout keeps no credentials.
+      # By default actions/checkout leaves the job's token in `.git/config`,
+      # where every later step — including a build script — can read it.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # rustup from the runner image, not dtolnay/rust-toolchain: that action
       # offers only branch refs, so there is nothing immutable to pin. See the
@@ -34,29 +47,60 @@ jobs:
             --target aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
           rustup default stable
 
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-release-ios-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-release-ios-
-            ${{ runner.os }}-cargo-
-
+      # Deliberately NO actions/cache here any more. A cache entry is writable
+      # by any job on any branch of this repo, and there is no way to tell a
+      # poisoned `~/.cargo/registry` from a warm one — so a release artifact
+      # built from a restored cache is a release artifact built from whatever
+      # the last branch to run this key put there. That artifact's sha256 is
+      # what vta-mobile-agent-ios pins in `Package.swift`, so it is exactly the
+      # input that must not be attacker-reachable. A release runs rarely;
+      # paying the cold build is the cheaper side of the trade.
       - name: Assemble VtaMobileCore.xcframework
         run: ./vta-mobile-core/scripts/package-ios.sh
 
+      # The handoff to `publish`. Only the three release assets cross it, so
+      # the privileged job never sees the build tree.
+      - name: Upload the packaged xcframework
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ios-xcframework
+          path: |
+            target/mobile/ios/VtaMobileCore.xcframework.zip
+            target/mobile/ios/VtaMobileCore.xcframework.zip.sha256
+            target/mobile/ios/Sources/VtaMobileCore.swift
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    # Tag pushes only: a workflow_dispatch run is a packaging smoke test and
+    # has no business cutting a release.
+    #
+    # This job compiles nothing, runs no third-party action beyond the artifact
+    # download, and does not even check the repository out — `gh` addresses it
+    # by name. That is the whole point of the split: `contents: write` is held
+    # for one `gh release create` over three files, not for a Rust build.
+    name: Publish the GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write # create the Release + upload assets
+    steps:
+      - name: Download the packaged xcframework
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ios-xcframework
+          path: dist
+
       - name: Publish GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
           DOWNLOAD_BASE: ${{ github.server_url }}/${{ github.repository }}/releases/download
         run: |
           set -euo pipefail
-          out="target/mobile/ios"
+          out="dist"
           checksum="$(cat "$out/VtaMobileCore.xcframework.zip.sha256")"
           url="$DOWNLOAD_BASE/$TAG/VtaMobileCore.xcframework.zip"
           notes="$RUNNER_TEMP/release-notes.md"

--- a/docs/05-design-notes/vtc-ceremony-visual-guide.html
+++ b/docs/05-design-notes/vtc-ceremony-visual-guide.html
@@ -7,7 +7,19 @@
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400&family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap" rel="stylesheet" />
-<script src="https://d3js.org/d3.v7.min.js"></script>
+<!-- d3, pinned to an exact version and checked on arrival. The previous src
+     was https://d3js.org/d3.v7.min.js: a FLOATING major-version URL, whose
+     bytes change with every 7.x release, so it cannot carry an `integrity`
+     digest at all — any digest would be a lie the next time d3 shipped. This
+     URL is immutable (jsDelivr serves npm `d3@7.9.0` by version), so the
+     digest below is checkable, and the browser refuses to execute the script
+     if the CDN ever returns bytes that do not match it. `crossorigin` is
+     required for the check on a cross-origin script and sends no credentials.
+     The digest is sha384 over npm d3 7.9.0, which is byte-identical to what
+     d3js.org was serving for v7. -->
+<script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js"
+        integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i"
+        crossorigin="anonymous"></script>
 <style>
   :root{
     --bg:#090c12; --bg-2:#0c1018; --panel:#10141d; --panel-2:#141a24;

--- a/scripts/check-workflow-action-pins.sh
+++ b/scripts/check-workflow-action-pins.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Every `uses:` in this repository must name a 40-hex commit SHA.
+#
+# ## What this is protecting
+#
+# A third-party action runs with the job's token and the job's secrets. `@v4`,
+# `@stable` and `@cargo-llvm-cov` are all MOVABLE names: a tag can be deleted
+# and recreated on new code, and a branch moves whenever its author pushes. So
+# a green CI run says nothing about what will run on the next one, and the
+# repository has already been on the wrong side of that — `dtolnay/rust-
+# toolchain@stable` resolved to 4360b525 on 2026-09-02 and to 6bed0761 nine
+# days later, on jobs that included `publish.yml`, which holds `id-token:
+# write` and mints a crates.io token.
+#
+# A SHA cannot be repointed. Pinning is not a nicety here: crates.io Trusted
+# Publishing means this repository's workflows ARE the publishing credential.
+#
+# ## What it checks
+#
+# 1. Every `uses:` ref is `owner/repo@<40 hex>` (or a local `./` action, which
+#    is part of this commit and so already pinned by definition).
+# 2. Each pin carries a trailing `# vX.Y.Z` comment. That comment is not
+#    decoration — it is what makes the pin legible to a human reviewer, and
+#    Dependabot reads and rewrites it when it moves the SHA. A pin with no
+#    comment is a pin nobody will ever update.
+#
+# The org-level "require actions to be pinned to a full-length commit SHA"
+# policy enforces (1) for real, once it is enabled. This runs in the meantime,
+# it also enforces (2), and it fails the PR that introduces the problem rather
+# than the run after it.
+set -euo pipefail
+
+# Filled with a read loop rather than `mapfile`, which is bash 4 and therefore
+# absent on a macOS developer machine. This guard is meant to be runnable
+# before it is pushed.
+files=()
+while IFS= read -r f; do
+  files+=("$f")
+done < <(git ls-files -- \
+  '.github/workflows/*.yml' '.github/workflows/*.yaml' \
+  '.github/actions/**/action.yml' '.github/actions/**/action.yaml')
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "::error::no workflow files found — this guard is looking in the wrong place"
+  exit 1
+fi
+
+bad=0
+checked=0
+
+while IFS= read -r hit; do
+  file=${hit%%:*}
+  rest=${hit#*:}
+  lineno=${rest%%:*}
+  text=${rest#*:}
+
+  # The ref is the first whitespace-delimited token after `uses:`.
+  ref=$(printf '%s\n' "$text" | sed -E 's/.*uses:[[:space:]]*//; s/[[:space:]].*//')
+  # The version comment, if any, is what follows a `#` after that token.
+  comment=$(printf '%s\n' "$text" \
+    | sed -nE 's/.*uses:[[:space:]]*[^[:space:]]+[[:space:]]+#[[:space:]]*(.+)$/\1/p')
+
+  case "$ref" in
+    # A local action or reusable workflow is this commit's own content.
+    ./* | docker://*) continue ;;
+  esac
+
+  checked=$((checked + 1))
+
+  if [[ ! "$ref" =~ ^[^@]+@[0-9a-f]{40}$ ]]; then
+    printf '%s:%s: not pinned to a 40-hex commit SHA: %s\n' "$file" "$lineno" "$ref"
+    bad=1
+    continue
+  fi
+
+  if [ -z "$comment" ]; then
+    printf '%s:%s: pinned, but with no `# vX.Y.Z` comment: %s\n' "$file" "$lineno" "$ref"
+    bad=1
+  fi
+done < <(grep -HnE '^[[:space:]]*(-[[:space:]]+)?uses:' "${files[@]}")
+
+if [ "$bad" -ne 0 ]; then
+  echo "::error::every \`uses:\` must be pinned to a 40-hex commit SHA with a \`# vX.Y.Z\` comment"
+  cat <<'MSG'
+
+Resolve the tag to a commit and write both, for example:
+
+  - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+To find the SHA a tag points at (dereferencing an annotated tag):
+
+  gh api repos/actions/checkout/git/ref/tags/v7 --jq .object
+
+If the only refs an action publishes are BRANCHES, do not pin the branch tip:
+there is nothing for Dependabot to bump afterwards. Either inline what the
+action does (this repo installs Rust with `rustup` for exactly that reason) or
+use the action's versioned entry point with the tool named in `with:`.
+MSG
+  exit 1
+fi
+
+echo "all $checked external \`uses:\` refs are pinned to a commit SHA with a version comment"


### PR DESCRIPTION

Every `uses:` in this repository resolved through a mutable name, and two
workflows had no `permissions:` block at all. Those two facts compose badly:
an action that can change under us was running in a job that held a write
token, and in one case a crates.io publishing identity.

Five commits, one concern each.

## 1. Pin every action (58 refs)

`@v7` and `@stable` are movable names. A tag can be deleted and recreated on
new code; a branch moves whenever its author pushes. So a green run said
nothing about the next one — and this repository has already been on the wrong
side of it. The CI log captured in #1239 shows `dtolnay/rust-toolchain@stable`
resolving to `4360b525` on 2026-09-02 and `6bed0761` nine days later, on jobs
including `publish.yml`.

- **41 refs** are now `@<40-hex> # vX.Y.Z`. The version lives in the comment
  because that is the form Dependabot updates: it moves the SHA and rewrites
  the comment.
- **17 refs were branch refs** — `dtolnay/rust-toolchain@stable` (16) and
  `@master` (1). That action publishes no release tags at all, so pinning it
  would freeze it at a commit nothing could ever bump. They are replaced with
  the two `rustup` lines the action was running for us; rustup ships on every
  hosted runner. `components:`/`targets:` become `--component`/`--target`, and
  the MSRV job's toolchain now reaches the shell through `env:` instead of
  being spliced into it.
- `taiki-e/install-action@cargo-semver-checks` was a third shape of the same
  problem: a tool-named tag re-pointed on every release of that tool. It is now
  the pinned `v2` action with `with: tool: cargo-semver-checks`.

The privileged files (`publish.yml`, `release-mobile-ios.yml`) were done first.
Every SHA was resolved with `gh api`, dereferencing annotated tags, and
re-checked against its comment afterwards.

## 2. Least privilege

`ci.yml` and `docker.yml` inherited the repository default token, which is
write-all. The #1239 log recorded an ordinary same-repo PR run holding
`Contents: write, Actions: write, Checks: write, Deployments: write, …`. Fork
PRs were already read-only, so the exposure was pushes, `merge_group` and
same-repo PR runs. Both now declare `contents: read` at the top level; neither
needs more.

`release-mobile-ios.yml` held `contents: write` at the **top level** over one
job that cross-compiles three Apple targets. It is now:

- a `build` job under the read-only default, and
- a `publish` job with `contents: write` that compiles nothing, does not check
  the repository out, and runs one `gh release create` over three assets handed
  to it through an artifact.

Publishing is also now gated on a tag at the job level, so a `workflow_dispatch`
packaging smoke test cannot reach the release path. `actions/cache` is gone from
that path: a cache entry is writable from any branch and a poisoned
`~/.cargo/registry` is indistinguishable from a warm one, and the sha256 of
this artifact is what `vta-mobile-agent-ios` pins in `Package.swift`.

18 checkouts that push nothing now set `persist-credentials: false`.

## 3. Dependabot

`cooldown.default-days: 7` on the cargo, github-actions and docker entries, so
a release has to survive a week of ecosystem attention before it is proposed.
Security updates are exempt by design, so advisories still arrive immediately.
github-actions moves monthly → weekly, since SHA pins now only move when
Dependabot moves them. The comment claiming `rust-toolchain@master` and
`install-action@cargo-semver-checks` were unversionable is gone, because they
are.

Adds the entry `deploy/nitro/enclave-proxy` never had: it is its own workspace
with its own `Cargo.lock`, excluded from the root workspace because tokio-vsock
is Linux-only, so the `/` cargo entry has never seen it.

## 4. Docs SRI

`docs/05-design-notes/vtc-ceremony-visual-guide.html` loaded
`https://d3js.org/d3.v7.min.js` with no integrity attribute. **Chosen: a pinned
CDN URL with `integrity` + `crossorigin`**, not vendoring — the floating `v7`
URL was itself the reason no digest was possible, so the version pin
(`cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js`) had to come first, and adding
280 KB of minified JavaScript to a Rust workspace was not worth avoiding a
digest-checked fetch. The pinned bytes are byte-identical to what d3js.org was
serving for v7, so the page renders as before.

## 5. A guard that keeps the pins honest

`scripts/check-workflow-action-pins.sh` fails on any `uses:` that is not a
40-hex SHA, and on a SHA with no `# vX.Y.Z` comment. It runs as a step in the
existing cheap-guards job rather than as a new workflow, because a new job is a
new status check and a check nobody has made required does not gate anything —
this gates on day one. Local `./` actions are exempt.

**Why not zizmor:** `zizmor`'s `unpinned-uses` audit covers this and more and is
the better long-term answer, but adopting it means a repo-wide rollout plus a
required-check change, and it brings a new third-party action into the repo we
just finished pinning. Deliberately left as a follow-up.

## Verification

- Every changed YAML parses under `python3 -c 'yaml.safe_load(...)'`.
- `git grep -nE 'uses: *[^ .][^ ]*@' -- .github | grep -vE '@[0-9a-f]{40}( |$)'`
  prints nothing.
- The guard passes on this branch (42 external refs) and exits 1 with 58
  findings against `origin/main`.
- Every SHA re-resolved to the version in its comment via `gh api`.
- **actionlint v1.7.7**: 16 shellcheck notes, the same 16 as on `origin/main`
  (pre-existing `SC2086` in the apt-get blocks and `SC2153` in the soak
  workflow). No new findings.
- **zizmor v1.14.2** (`--persona regular`): `origin/main` reports 70 findings
  (29 high); this branch reports **none**. Both tools were run ephemerally
  (`go run` and a `cargo install --root` into a scratch dir) — nothing was
  installed globally.

Note that zizmor skipped its registry audits (`impostor-commit`,
`ref-confusion`, `known-vulnerable-actions`, `stale-action-refs`,
`ref-version-mismatch`) for want of a GitHub token, so those have not been run
against these pins.

No behaviour change is intended anywhere. The jobs worth watching on the first
run are `mobile`, `enclave` and `msrv`, since those are the toolchain
installations with components and targets.

## Admin settings still outstanding (not code, so not in this PR)

1. **Environments**: `crates-io` on `publish.yml`'s `release-plz-release`, and
   `release` on the new iOS `publish` job — each with required reviewers
   (`@OpenVTC/openvtc-maintainers`, ≥1) and "prevent self-review" on.
2. **crates.io Trusted Publishing**: bind the environment per crate. Until this
   is done, any writer who can dispatch a workflow can mint a publishing token.
   This is the step that makes the dispatch path non-exploitable.
3. **Tag ruleset**: restrict create/update/delete of `refs/tags/v*` and
   `refs/tags/vta-mobile-core-v*` to maintainers. Today any writer's tag push
   publishes.
4. **Branch ruleset on `main`**: required PR review, CODEOWNERS approval and
   required status checks. Only `DCO` is required today, so `CODEOWNERS` is
   decorative.
5. **Org Actions policy**: `default_workflow_permissions=read`;
   `allowed_actions=selected` with `sha_pinning_required=true` once the other
   repos are pinned; check `fork-pr-contributor-approval`.
6. **`RELEASE_PLZ_TOKEN`**: replace the PAT with a GitHub App installation
   token scoped to contents + pull_requests.
