### PR TITLE
security(vtc-admin-ui): render a plugin icon as an image, not as markup

### DIFF
--- a/vtc-service/admin-ui/src/App.test.tsx
+++ b/vtc-service/admin-ui/src/App.test.tsx
@@ -1,0 +1,91 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PluginIcon } from "@/App";
+import type { PluginManifest } from "@/plugin-api";
+
+/** A third-party manifest whose only interesting member is the icon. */
+function pluginWith(icon: string): PluginManifest {
+  return {
+    id: "third-party",
+    label: "Third party",
+    path: "/third-party",
+    elementTag: "x-third-party",
+    icon,
+  };
+}
+
+/** Every `on*` attribute anywhere in the rendered output. */
+function eventHandlerAttributes(root: HTMLElement): string[] {
+  return Array.from(root.querySelectorAll("*")).flatMap((el) =>
+    Array.from(el.attributes)
+      .map((a) => a.name)
+      .filter((name) => name.startsWith("on")),
+  );
+}
+
+describe("PluginIcon", () => {
+  it("renders a plugin's SVG icon as an image, so nothing inside it can run", () => {
+    // The icon string is attacker-shaped: `script-src 'self'` would stop a
+    // `<script>` here, but it says nothing about an inline handler, which is
+    // why injecting this as markup was the finding.
+    const { container } = render(
+      <PluginIcon
+        plugin={pluginWith(
+          '<svg onload="globalThis.__pluginIconRan = true"><rect /></svg>',
+        )}
+      />,
+    );
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toMatch(
+      /^data:image\/svg\+xml;charset=utf-8,/,
+    );
+    // The decisive assertion: the SVG is not in the document as DOM, so
+    // there is no element for the handler to be attached to.
+    expect(container.querySelector("svg")).toBeNull();
+    expect(eventHandlerAttributes(container)).toEqual([]);
+    expect(
+      (globalThis as Record<string, unknown>).__pluginIconRan,
+    ).toBeUndefined();
+  });
+
+  it("keeps the icon's bytes intact, so a legitimate SVG still draws", () => {
+    // Rendering it safely is only half the requirement; a plugin's icon still
+    // has to arrive unmangled.
+    const icon = '<svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="7" /></svg>';
+    const { container } = render(<PluginIcon plugin={pluginWith(icon)} />);
+
+    const src = container.querySelector("img")?.getAttribute("src") ?? "";
+    const payload = src.replace("data:image/svg+xml;charset=utf-8,", "");
+    expect(decodeURIComponent(payload)).toBe(icon);
+  });
+
+  it("renders markup that is not an SVG as text", () => {
+    const icon = '<img src=x onerror="globalThis.__pluginIconRan = true">';
+    const { container } = render(<PluginIcon plugin={pluginWith(icon)} />);
+
+    // No element of any kind — React escaped the string.
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toBe(icon);
+    expect(
+      (globalThis as Record<string, unknown>).__pluginIconRan,
+    ).toBeUndefined();
+  });
+
+  it("renders a single glyph as itself", () => {
+    const { container } = render(<PluginIcon plugin={pluginWith("★")} />);
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toBe("★");
+  });
+
+  it("falls back to the label's first letter when there is no icon", () => {
+    const { container } = render(
+      <PluginIcon plugin={{ id: "vetting", label: "vetting", path: "/vetting" }} />,
+    );
+
+    expect(container.textContent).toBe("V");
+  });
+});

--- a/vtc-service/admin-ui/src/App.tsx
+++ b/vtc-service/admin-ui/src/App.tsx
@@ -242,7 +242,14 @@ export default function App() {
   );
 }
 
-function PluginIcon({ plugin }: { plugin: PluginManifest }) {
+/**
+ * The nav's icon slot for one plugin.
+ *
+ * Exported for its own test: the `<img>` below is a security property, not a
+ * styling choice, and a later refactor back to injected markup would look like
+ * a simplification.
+ */
+export function PluginIcon({ plugin }: { plugin: PluginManifest }) {
   // Built-in plugins ship a lucide-react component; third-party
   // plugins fall back to the `icon` string (inline SVG or single
   // glyph). If neither is set, fall back to the label's first
@@ -252,14 +259,29 @@ function PluginIcon({ plugin }: { plugin: PluginManifest }) {
     return <Icon aria-hidden="true" />;
   }
   if (plugin.icon) {
-    if (plugin.icon.trim().startsWith("<")) {
+    // An SVG icon is rendered as an image, never injected as markup.
+    //
+    // This used to be `dangerouslySetInnerHTML`, which put the plugin's
+    // string into the document as live DOM. `script-src 'self'`
+    // (`vtc-service/src/routing/security_headers.rs`) stops a `<script>` in
+    // it from executing — but an `onload=` / `onerror=` attribute is not
+    // script-src's business, and `icon` reaches the shell from plugin
+    // JavaScript that a third party may have written.
+    //
+    // Inside an `<img>` an SVG is a picture: the browser renders it in a
+    // non-scripted context, so neither scripts nor event handlers in it ever
+    // run, and `img-src 'self' data:` already admits the data URL. No
+    // sanitiser, and so no dependency on one being configured correctly.
+    if (/^<svg[\s>]/i.test(plugin.icon.trim())) {
+      const src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(
+        plugin.icon,
+      )}`;
       return (
-        <span
-          className="plugin-icon-raw"
-          dangerouslySetInnerHTML={{ __html: plugin.icon }}
-        />
+        <img className="plugin-icon-raw" src={src} alt="" aria-hidden="true" />
       );
     }
+    // Anything else is text — a glyph or emoji as before, and markup that is
+    // not an SVG as its own characters, because React escapes it.
     return <span aria-hidden="true">{plugin.icon}</span>;
   }
   return <span aria-hidden="true">{plugin.label.charAt(0).toUpperCase()}</span>;

--- a/vtc-service/admin-ui/src/plugin-api.ts
+++ b/vtc-service/admin-ui/src/plugin-api.ts
@@ -61,6 +61,22 @@ export interface PluginManifest {
    * plugins. Built-in React plugins should prefer `iconComponent`,
    * which renders a proper lucide-react icon and inherits the shell's
    * 16px stroke-1.75 styling. Set at most one.
+   *
+   * **How the shell renders this.** A string starting with `<svg` is
+   * rendered as `<img src="data:image/svg+xml,…">` — a picture, not
+   * markup. Nothing inside it executes: scripts and `on*` handlers
+   * never run in an `<img>`, which is what lets the shell accept SVG
+   * from a plugin it does not control.
+   *
+   * The consequence for authors is that an `<img>` is a separate
+   * document, so it inherits nothing from the shell: `currentColor`
+   * and the 1.75 stroke width do **not** apply. Give the SVG its own
+   * explicit colours and a `viewBox` sized against a 16px box, or
+   * ship an `iconComponent` instead when the icon needs to follow the
+   * theme.
+   *
+   * Any other string is rendered as text, so markup that is not an
+   * SVG appears as its own characters rather than as elements.
    */
   readonly icon?: string;
   /**

--- a/vtc-service/admin-ui/src/styles.css
+++ b/vtc-service/admin-ui/src/styles.css
@@ -510,6 +510,16 @@ button.primary:focus-visible {
   stroke-width: 1.75;
 }
 
+/* A third-party plugin's SVG icon arrives as an `<img>` rather than as inline
+   markup (see `PluginIcon` — nothing inside an `<img>` can execute), so the
+   `svg` rule above never sees it and cannot size it. */
+.nav-icon img,
+.plugin-icon-raw {
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
+}
+
 .nav-label {
   flex: 1 1 auto;
   overflow: hidden;


### PR DESCRIPTION

`PluginIcon` in `vtc-service/admin-ui/src/App.tsx` passed `plugin.icon` to
`dangerouslySetInnerHTML`, putting a plugin-supplied string into the document
as live DOM.

`script-src 'self'` (`vtc-service/src/routing/security_headers.rs:52-59`) stops
a `<script>` element in that string from executing, which is why this is Low
rather than High. But an `onload=` / `onerror=` attribute is not `script-src`'s
business, and `icon` arrives from plugin JavaScript
(`plugin-api.ts`) — first-party today, third-party by design.

## What changed

A string starting with `<svg` is rendered as an image:

```tsx
const src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(plugin.icon)}`;
return <img className="plugin-icon-raw" src={src} alt="" aria-hidden="true" />;
```

Inside an `<img>` an SVG is a picture: the browser renders it in a non-scripted
context, so neither scripts nor event handlers in it ever run. `img-src 'self'
data:` is **already** in the CSP, so no header change is needed — and no
sanitiser, so nothing depends on DOMPurify being added and configured
correctly (it is not in `admin-ui/package.json`, and this change keeps it that
way).

Any other string renders as text. Previously *any* string starting with `<` was
injected; now markup that is not an SVG (`<img src=x onerror=…>`) appears as
its own characters, because React escapes it.

Two smaller pieces:

- The `icon` doc comment in `plugin-api.ts` now states the rendering **and its
  consequence for authors**: an `<img>` is a separate document, so the icon
  inherits neither `currentColor` nor the shell's 1.75 stroke width. A plugin
  whose icon must follow the theme should ship an `iconComponent` instead.
  Worth saying explicitly, because it is a real (if minor) behaviour change for
  any third-party plugin currently relying on inheritance.
- `.nav-icon img` keeps the 16px box. The existing `.nav-icon svg` rule sized
  the injected SVG and does not match an `<img>`, so without this the icon
  would render at its intrinsic size.

## Tests

The admin UI **does** have its own test setup (vitest + Testing Library +
jsdom, `vitest.config.ts`, `npm test`), so this uses it rather than a CI grep
guard. `PluginIcon` is now exported and covered by a new
`vtc-service/admin-ui/src/App.test.tsx`:

- an SVG carrying `onload="globalThis.__pluginIconRan = true"` renders as an
  `<img>` with a `data:image/svg+xml` src, **no `<svg>` in the document**, no
  `on*` attribute on any element, and the global unset;
- a legitimate SVG survives the round trip byte for byte
  (`decodeURIComponent` of the payload equals the input) — rendering it safely
  is only half the requirement;
- non-SVG markup renders as text;
- a single glyph and the label-initial fallback still behave.

**One thing for a reviewer to decide.** Nothing in `.github/` runs `npm test`
or `npm run lint` — grepping the workflows for `vitest` / `npm test` / `npm ci`
finds nothing; `vtc-service`'s `build.rs` only runs `npm run build`. So this
test will not run in CI as things stand, and the regression it pins could
return unnoticed. Two options, neither taken here to keep the diff to the
finding: add a vitest job to `ci.yml` (better, and it would cover the 82
existing tests too), or add the grep guard for `dangerouslySetInnerHTML` under
`vtc-service/admin-ui/src` that the remediation plan suggested as the fallback.
Happy to add either in this PR on request.

## Verification

Run in `vtc-service/admin-ui`:

- `npm test` — **10 files, 82 tests passed** (9 files / 77 tests before; the
  new file adds 5).
- `npm run lint` (`wire:check` + `tsc -b --noEmit`) — passes.

There is no `dangerouslySetInnerHTML` **call** left under
`vtc-service/admin-ui/src`. One textual hit remains, in the comment at
`App.tsx:264` explaining what the code used to do and why it changed — worth
knowing if the grep-guard option above is taken, since the naive pattern would
match that comment. A guard would need to match the JSX usage (e.g.
`dangerouslySetInnerHTML={`) rather than the bare identifier, or the comment
would have to stop naming the API, which would cost the reader the reason.

`package-lock.json` is untouched.
