### PR TITLE
security(resolver)!: refuse did:webvh resolution to non-public hosts by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.36"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d261ce9e5886c890492a1ed7ae6f0b286f8c8c2c711af96eb1bdf1eee9efa6"
+checksum = "be0b2e768c75df1d0bca72f51ecb6bbb37fccc13e16bf9c093f8fc04e429e952"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-traits",
@@ -257,16 +257,16 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-web"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8fc4d44f666b034f50cd753afc1bdfef6d7801cccc35672518ab2e2fda007c"
+checksum = "08ba8e331d31ff1c6bf9f5684d71471779e5f9fbf7167d93a4a34f2daece202b"
 dependencies = [
  "affinidi-did-common",
+ "affinidi-net-guard",
  "percent-encoding",
  "reqwest",
  "serde_json",
  "thiserror 2.0.20",
- "tokio",
  "tracing",
 ]
 
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f6e935295f1c9eec0fa7ee609f3f6e88f855b788712dbfac334c50279dbdf0"
+checksum = "3b6e6bc49148927068b3bb42e32e7ec3a26c8a1a118cd682acd6b876f0071e55"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -554,6 +554,19 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "affinidi-net-guard"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43736e64c051b4689d39c08e781dae750a79fee9bbf44e4eb7ed93e081485184"
+dependencies = [
+ "reqwest",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -735,14 +748,15 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk-common"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864083bc98bc29e8ed049b8c477532f9f435a6befe75edb9cac2d9cf257842ec"
+checksum = "d6235d6d0506aed283966e11bbe4bf1e6cda94e0188aa09db15d9be95d3aa61f"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-net-guard",
  "affinidi-secrets-resolver",
  "ahash",
  "apple-native-keyring-store",
@@ -3230,7 +3244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.5",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3483,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "did-scid"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c7754d192a630118d5fa3353f1cce5c291187762b0e493f397d3e0328b407d"
+checksum = "32bb54e6769f547fc641bbe63bb06f253fe41ad552e47e24cbd6c62a7b6436d8"
 dependencies = [
  "affinidi-did-common",
  "didwebvh-rs",
@@ -3515,9 +3529,9 @@ dependencies = [
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a6d8803724264019c1b1dda174b4f666b833e9ac05acd45e87e9fecef2c67b"
+checksum = "1aa08dc5af02f6bc159c10271195f467a894b3b4fe67da9796009ee2da785043"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-common",
@@ -7225,7 +7239,7 @@ dependencies = [
  "aes-gcm 0.10.3",
  "aes-kw",
  "argon2 0.5.3",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfields",
  "block-padding 0.3.3",
  "blowfish",
@@ -8742,7 +8756,7 @@ checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,23 @@ rand = "0.10"
 pgp = { version = "0.20", default-features = false }
 
 # DID Web with Verifiable History
-didwebvh-rs = "0.6"
+#
+# 0.7 is a security floor, not a preference. Through 0.6.1 `resolve()` rejected
+# IP-literal hosts and nothing else: `did:webvh:{SCID}:localhost%3A<port>` was
+# fetched over plain `http://`, and any other name was fetched from whatever
+# address it resolved to — so a did:webvh DID naming an internal host, or a
+# public name whose A record points at 169.254.169.254, was a resolver-side SSRF
+# for every crate in this workspace that resolves a DID. 0.7 refuses non-public
+# hosts by default (`HostPolicy::PublicOnly`), vets DNS answers before
+# connecting, refuses redirects and ignores `HTTP(S)_PROXY`.
+#
+# A caret on "0.6" would let a resolve land back on 0.6.1 and reintroduce that,
+# which is why this is not a bare major.minor onto the old series.
+#
+# Local webvh stacks (`local-dev/vta-*-webvh-setup.toml`, which publish
+# `http://localhost:3000`) and tests that resolve a listener on 127.0.0.1 must
+# now opt in explicitly with `HostPolicy::AllowPrivate`.
+didwebvh-rs = "0.7"
 
 # URL parsing
 url = "2"
@@ -398,7 +414,16 @@ k8s-openapi = { version = "0.28", features = ["latest"] }
 # Hoist DID-resolver-cache feature drift: every crate uses 0.8 but a few
 # omit the `network` feature. The default here turns it on; dependents
 # that want the offline-only cache can opt out via `default-features = false`.
-affinidi-did-resolver-cache-sdk = { version = "0.8", features = ["network"] }
+#
+# Pinned to a minimum patch (not a bare "0.8") because 0.8.37 is the release
+# that moves did:webvh resolution onto `didwebvh-rs` 0.7 and its
+# `HostPolicy::PublicOnly` default — see the note on `didwebvh-rs` above. This
+# is the crate every DID resolution in the workspace goes through
+# (`DIDCacheClient`), so a resolve that landed on 0.8.36 would leave did:webvh
+# resolution reaching localhost and private addresses while the tree looked
+# current. 0.8.35 did the same for did:web; 0.8.37 makes one
+# `DIDCacheConfigBuilder::with_host_policy` setting govern both.
+affinidi-did-resolver-cache-sdk = { version = "0.8.37", features = ["network"] }
 # The local-only resolvers, for methods that carry their keys in the identifier. Not a
 # second resolver: the cache SDK already depends on this and uses the same types, but does
 # not re-export them, and a verifier promising "no I/O" needs to reach them directly.

--- a/cnm-cli/src/main.rs
+++ b/cnm-cli/src/main.rs
@@ -1610,7 +1610,13 @@ async fn cmd_health(
     println!("  {CYAN}{:<13}{RESET} {}", "URL", client.endpoint_label());
 
     // Create a shared DID resolver for both sections
-    let resolver = match DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await {
+    let resolver = match DIDCacheClient::new(
+        DIDCacheConfigBuilder::default()
+            .with_host_policy(vta_sdk::resolver::webvh_host_policy())
+            .build(),
+    )
+    .await
+    {
         Ok(r) => Some(r),
         Err(e) => {
             println!("  {DIM}DID resolution skipped (resolver unavailable: {e}){RESET}");

--- a/deploy/nitro/enclave-proxy/Cargo.lock
+++ b/deploy/nitro/enclave-proxy/Cargo.lock
@@ -111,16 +111,16 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.34"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d96b5e9a4f92941ae4262a1d15729e234c49e598bd32598df8bf3db4d160b64"
+checksum = "be0b2e768c75df1d0bca72f51ecb6bbb37fccc13e16bf9c093f8fc04e429e952"
 dependencies = [
  "affinidi-did-common 0.4.2",
  "affinidi-did-resolver-traits",
  "affinidi-did-web",
  "ahash",
  "did-scid",
- "didwebvh-rs 0.6.1",
+ "didwebvh-rs",
  "highway",
  "moka",
  "rand 0.10.1",
@@ -146,11 +146,12 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-web"
-version = "0.1.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60190b239183934f3c14e21d966d10ee3c83297077bc24fbe55e8af15896317e"
+checksum = "08ba8e331d31ff1c6bf9f5684d71471779e5f9fbf7167d93a4a34f2daece202b"
 dependencies = [
- "affinidi-did-common 0.3.3",
+ "affinidi-did-common 0.4.2",
+ "affinidi-net-guard",
  "percent-encoding",
  "reqwest",
  "serde_json",
@@ -169,6 +170,19 @@ dependencies = [
  "thiserror",
  "unsigned-varint",
  "zeroize",
+]
+
+[[package]]
+name = "affinidi-net-guard"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43736e64c051b4689d39c08e781dae750a79fee9bbf44e4eb7ed93e081485184"
+dependencies = [
+ "reqwest",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -859,38 +873,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32bb54e6769f547fc641bbe63bb06f253fe41ad552e47e24cbd6c62a7b6436d8"
 dependencies = [
  "affinidi-did-common 0.4.2",
- "didwebvh-rs 0.7.0",
+ "didwebvh-rs",
  "regex",
  "serde_json",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "didwebvh-rs"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a6d8803724264019c1b1dda174b4f666b833e9ac05acd45e87e9fecef2c67b"
-dependencies = [
- "affinidi-data-integrity",
- "affinidi-did-common 0.4.2",
- "affinidi-secrets-resolver",
- "ahash",
- "async-trait",
- "base58",
- "chrono",
- "getrandom 0.4.2",
- "percent-encoding",
- "reqwest",
- "serde",
- "serde_json",
- "serde_json_canonicalizer",
- "serde_with",
- "sha2 0.11.0",
- "thiserror",
- "tokio",
- "tracing",
- "url",
 ]
 
 [[package]]

--- a/deploy/nitro/enclave-proxy/Cargo.toml
+++ b/deploy/nitro/enclave-proxy/Cargo.toml
@@ -38,5 +38,9 @@ serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_json = "1"
-affinidi-did-resolver-cache-sdk = "0.8"
+# Minimum patch, matching the root workspace: 0.8.37 is the release whose
+# did:webvh resolution refuses non-public hosts by default. This proxy resolves
+# DIDs on the parent instance, outside the enclave, so it is exactly the place a
+# did:webvh DID naming an internal host would be fetched from.
+affinidi-did-resolver-cache-sdk = "0.8.37"
 fjall = "3"

--- a/local-dev/vta-pathful-webvh-setup.toml
+++ b/local-dev/vta-pathful-webvh-setup.toml
@@ -8,6 +8,25 @@
 # Then start the service:
 #   cargo run -p vta-service --features webvh -- --config /tmp/vta-dev-path/config.toml
 #
+# Loopback DIDs need an explicit opt-in:
+#   export VTA_ALLOW_PRIVATE_ENDPOINTS=1
+#
+# This setup mints `did:webvh:{SCID}:localhost%3A3000:tenant:vta`. Since
+# `didwebvh-rs` 0.7 (`affinidi-did-resolver-cache-sdk` 0.8.37), resolving a
+# did:webvh or did:web DID whose host is loopback, private, link-local or a
+# single-label name is refused before any request is made — that is what stops a
+# DID naming an internal host from making a VTA fetch from inside its own
+# network. The readiness gate, `vta status`, `vta create-did-webvh` and the
+# `vta webvh` commands all resolve this DID, so export the variable for every
+# command in this local stack, `setup` included.
+#
+# Without it those commands fail with `BlockedHost: localhost is not a public
+# host (HostPolicy::PublicOnly)` and mediator readiness never goes green.
+#
+# It is the same switch as `--allow-private-endpoints` on `pnm`/`cnm`. Do NOT
+# set it in a deployment: it also lets did:web reach private hosts, and a
+# `localhost` DID is then fetched over plain `http://`.
+#
 # Verify:
 #   curl http://localhost:3000/tenant/vta/did.jsonl    → 200 with log
 #   curl http://localhost:3000/.well-known/did.jsonl   → 404 (pathful DID does not use well-known)

--- a/local-dev/vta-root-webvh-setup.toml
+++ b/local-dev/vta-root-webvh-setup.toml
@@ -8,6 +8,25 @@
 # Then start the service:
 #   cargo run -p vta-service --features webvh -- --config /tmp/vta-dev-root/config.toml
 #
+# Loopback DIDs need an explicit opt-in:
+#   export VTA_ALLOW_PRIVATE_ENDPOINTS=1
+#
+# This setup mints `did:webvh:{SCID}:localhost%3A3000`. Since `didwebvh-rs` 0.7
+# (`affinidi-did-resolver-cache-sdk` 0.8.37), resolving a did:webvh or did:web
+# DID whose host is loopback, private, link-local or a single-label name is
+# refused before any request is made — that is what stops a DID naming an
+# internal host from making a VTA fetch from inside its own network. The
+# readiness gate, `vta status`, `vta create-did-webvh` and the `vta webvh`
+# commands all resolve this DID, so export the variable for every command in
+# this local stack, `setup` included.
+#
+# Without it those commands fail with `BlockedHost: localhost is not a public
+# host (HostPolicy::PublicOnly)` and mediator readiness never goes green.
+#
+# It is the same switch as `--allow-private-endpoints` on `pnm`/`cnm`. Do NOT
+# set it in a deployment: it also lets did:web reach private hosts, and a
+# `localhost` DID is then fetched over plain `http://`.
+#
 # Verify:
 #   curl http://localhost:3000/.well-known/did.jsonl   → 200 with log
 #   curl http://localhost:3000/any/path/did.jsonl      → 404

--- a/vta-sdk/src/client/mod.rs
+++ b/vta-sdk/src/client/mod.rs
@@ -2013,6 +2013,7 @@ impl VtaClient {
             .get_or_init(|| async {
                 affinidi_did_resolver_cache_sdk::DIDCacheClient::new(
                     affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default()
+                        .with_host_policy(crate::resolver::webvh_host_policy())
                         .build(),
                 )
                 .await

--- a/vta-sdk/src/didcomm_light.rs
+++ b/vta-sdk/src/didcomm_light.rs
@@ -168,11 +168,30 @@ async fn resolve_webvh_keyagreement(
 ) -> Result<(String, [u8; 32]), Box<dyn std::error::Error>> {
     use didwebvh_rs::DIDWebVHState;
     use didwebvh_rs::log_entry::LogEntryMethods;
-    use didwebvh_rs::resolve::ResolveOptions;
+    use didwebvh_rs::resolve::{HostPolicy, ResolveOptions};
+
+    // `ResolveOptions::default()` is `HostPolicy::PublicOnly`, which is what
+    // production wants: this fetches a log from a host named by the DID we were
+    // handed, so a DID naming an internal host must not make us dial it. Local
+    // development against `did:webvh:{SCID}:localhost%3A3000` opts in through
+    // the same switch as the rest of the workspace — see
+    // `crate::resolver::allow_private_did_hosts`.
+    //
+    // The bool is mapped here rather than reusing `resolver::webvh_host_policy`
+    // because that returns the resolver-cache's `HostPolicy` re-export, which is
+    // a different type from `didwebvh_rs`' own.
+    let host_policy = if crate::resolver::allow_private_did_hosts() {
+        HostPolicy::AllowPrivate
+    } else {
+        HostPolicy::PublicOnly
+    };
 
     let mut state = DIDWebVHState::default();
     let (log_entry, _meta) = state
-        .resolve(vta_did, ResolveOptions::default())
+        .resolve(
+            vta_did,
+            ResolveOptions::default().with_host_policy(host_policy),
+        )
         .await
         .map_err(|e| format!("resolve did:webvh {vta_did}: {e}"))?;
     let did_doc = log_entry

--- a/vta-sdk/src/display_name/agent_name.rs
+++ b/vta-sdk/src/display_name/agent_name.rs
@@ -155,7 +155,8 @@ pub async fn lookup(client: &DIDCacheClient, did: &str) -> Option<DisplayName> {
 /// here too. Per-DID failures are skipped, not propagated: an unreachable name
 /// server must degrade a row to its DID, never fail the operator's command.
 pub async fn fill_book<'a>(book: &mut super::NameBook, dids: impl IntoIterator<Item = &'a str>) {
-    let mut builder = DIDCacheConfigBuilder::default();
+    let mut builder =
+        DIDCacheConfigBuilder::default().with_host_policy(crate::resolver::webvh_host_policy());
     if let Ok(url) = std::env::var("PNM_RESOLVER_URL")
         && !url.is_empty()
     {

--- a/vta-sdk/src/lib.rs
+++ b/vta-sdk/src/lib.rs
@@ -154,9 +154,20 @@ pub mod prelude;
 // classifies `trust_tasks`' URI catalog), so a retry layer can consult it
 // without pulling in the client machinery.
 pub mod retry_safety;
-// `resolver` wraps `affinidi-did-resolver-cache-sdk`, which is only a
-// dependency under the `didcomm` feature.
-#[cfg(feature = "didcomm")]
+// `resolver` wraps `affinidi-did-resolver-cache-sdk`. The cfg lists every
+// feature that adds that dependency, not just `didcomm`: this module now also
+// owns the loopback-host decision (`webvh_host_policy`), and each of these
+// features has a resolver-construction site that has to ask for it —
+// `didcomm_light` under `client` (which implies `proof-verify`),
+// `display_name::agent_name` under `agent-names`. Gating on `didcomm` alone
+// made those builds fail to find it.
+#[cfg(any(
+    feature = "proof-verify",
+    feature = "didcomm",
+    feature = "tsp",
+    feature = "agent-names",
+    feature = "session"
+))]
 pub mod resolver;
 // `protocol` itself is always-on (its `services` submodule holds pure
 // wire types + the shared `validate_service_url` validator that

--- a/vta-sdk/src/resolver.rs
+++ b/vta-sdk/src/resolver.rs
@@ -22,15 +22,91 @@
 //! resolver explicitly from their own config (`server.rs` calls
 //! `with_network_mode(url)` directly), so PNM's setting does not leak
 //! into long-running daemons that have their own opinion.
+//!
+//! ## Host policy: which hosts a DID may be fetched from
+//!
+//! `affinidi-did-resolver-cache-sdk` 0.8.37 (`didwebvh-rs` 0.7) refuses
+//! non-public hosts for **both** `did:web` and `did:webvh` by default.
+//! `localhost`, `*.localhost`, `*.local`, `*.internal`, `home.arpa` and
+//! single-label names are refused before any request is made, and on native
+//! targets a name whose DNS answer contains a loopback, RFC 1918,
+//! carrier-grade-NAT or link-local address is refused at connect time — so a
+//! DID naming an internal host, or a public name whose A record points at
+//! `169.254.169.254`, can no longer be used to make this process fetch from
+//! the inside of its own network. The default client also refuses redirects
+//! and ignores `HTTP(S)_PROXY`.
+//!
+//! That default is what production wants, and nothing here weakens it. Local
+//! development is the case that needs an opt-out: `local-dev/*.toml` publish
+//! `http://localhost:3000`, so the VTA's own DID is
+//! `did:webvh:{SCID}:localhost%3A3000` and resolving it — which the readiness
+//! gate, `vta status` and the `webvh` CLI all do — is refused until the
+//! operator says loopback is expected.
+//!
+//! [`webvh_host_policy`] reads that decision from the switch this workspace
+//! already has for the same question about VTA REST endpoints taken out of a
+//! DID document: `VTA_ALLOW_PRIVATE_ENDPOINTS` (see
+//! [`crate::http::ALLOW_PRIVATE_ENDPOINTS_ENV`]) and the
+//! `--allow-private-endpoints` flag that sets it process-wide. One switch
+//! rather than a second one, because it is one question: may this process
+//! reach hosts that are not on the public internet? Note the cache SDK
+//! applies the policy to `did:web` and `did:webvh` together — there is no way
+//! to loosen one without the other — and that under `AllowPrivate` a
+//! `localhost` DID is fetched over plain `http://`.
 
 use affinidi_did_resolver_cache_sdk::config::{DIDCacheConfig, DIDCacheConfigBuilder};
+use affinidi_did_resolver_cache_sdk::network_resolvers::HostPolicy;
+
+/// Whether this process may resolve DIDs whose host is loopback or otherwise
+/// non-public.
+///
+/// `false` unless the operator opted in — see the module documentation. With
+/// the `client` feature this is the same answer
+/// [`crate::http::EndpointPolicy::process_default`] gives, so a binary that
+/// passes `--allow-private-endpoints` gets both halves from one flag; without
+/// it, the environment variable is read directly.
+pub fn allow_private_did_hosts() -> bool {
+    #[cfg(feature = "client")]
+    {
+        crate::http::EndpointPolicy::process_default().allow_private
+    }
+    #[cfg(not(feature = "client"))]
+    {
+        // Kept in step with `http::ALLOW_PRIVATE_ENDPOINTS_ENV`, which is not
+        // compiled without the `client` feature. Same name, same truthy set.
+        std::env::var("VTA_ALLOW_PRIVATE_ENDPOINTS")
+            .map(|v| {
+                matches!(
+                    v.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(false)
+    }
+}
+
+/// The [`HostPolicy`] every resolver this helper builds is configured with.
+///
+/// [`HostPolicy::PublicOnly`] — the secure default — unless
+/// [`allow_private_did_hosts`] says the operator opted in.
+pub fn webvh_host_policy() -> HostPolicy {
+    if allow_private_did_hosts() {
+        HostPolicy::AllowPrivate
+    } else {
+        HostPolicy::PublicOnly
+    }
+}
 
 /// Build a `DIDCacheConfig` honouring an optional remote-resolver URL.
 /// When `url` is `Some`, network-mode is enabled — every resolution is
 /// dispatched to that WebSocket endpoint. When `None`, the SDK resolves
 /// in-process with an in-memory cache.
+///
+/// The configured [`webvh_host_policy`] applies either way: in network mode a
+/// failed dispatch falls back to resolving locally, so the policy is not
+/// redundant just because a sidecar is configured.
 pub fn build_did_cache_config(url: Option<&str>) -> DIDCacheConfig {
-    let mut builder = DIDCacheConfigBuilder::default();
+    let mut builder = DIDCacheConfigBuilder::default().with_host_policy(webvh_host_policy());
     if let Some(u) = url {
         builder = builder.with_network_mode(u);
     }
@@ -44,4 +120,87 @@ pub fn build_did_cache_config_from_env() -> DIDCacheConfig {
         .ok()
         .filter(|s| !s.is_empty());
     build_did_cache_config(url.as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
+
+    /// A TCP listener on 127.0.0.1 that counts accepted connections.
+    async fn counting_listener() -> (u16, Arc<AtomicUsize>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let counter = accepted.clone();
+        tokio::spawn(async move {
+            while let Ok((socket, _)) = listener.accept().await {
+                counter.fetch_add(1, Ordering::SeqCst);
+                drop(socket);
+            }
+        });
+        (port, accepted)
+    }
+
+    /// The whole point of the `didwebvh-rs` 0.7 bump, asserted through the
+    /// construction path this workspace actually uses rather than through the
+    /// dependency's own API: a `did:webvh` DID naming a loopback host is
+    /// refused, and the listener it names is never connected to.
+    ///
+    /// Zero accepted connections is the assertion that matters. "Resolution
+    /// failed" alone would also be true of a fetch that happened and then hit
+    /// a parse error — which is exactly the SSRF this closes, since the
+    /// request itself is the leak. The listener answers nothing, so a refusal
+    /// that still dialled would show up here as a non-zero count.
+    #[tokio::test]
+    async fn default_config_refuses_loopback_webvh_did_without_connecting() {
+        let (port, accepted) = counting_listener().await;
+
+        // Built the way every VTA/CLI resolver in this workspace is built.
+        let client = DIDCacheClient::new(build_did_cache_config(None))
+            .await
+            .expect("local-mode DID cache client");
+
+        // Spellings that all canonicalise to loopback, plus a single-label
+        // name and a metadata name — each refused by `HostPolicy::PublicOnly`.
+        for host in [
+            "localhost",
+            "LOCALHOST",
+            "localhost.",
+            "svc.localhost",
+            "printer.local",
+            "metadata.google.internal",
+        ] {
+            let did = format!("did:webvh:QmScidNotResolvable:{host}%3A{port}");
+            let result = client.resolve(&did).await;
+            assert!(result.is_err(), "{did} resolved but should be refused");
+            let message = result.unwrap_err().to_string();
+            assert!(
+                message.contains("BlockedHost"),
+                "{did} failed for the wrong reason: {message}"
+            );
+        }
+
+        // Give any connection that was going to happen time to land.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            accepted.load(Ordering::SeqCst),
+            0,
+            "a refused did:webvh DID still connected to its host"
+        );
+    }
+
+    /// Without the opt-in the policy is the strict one. Guards against the
+    /// default being flipped by a later refactor of `build_did_cache_config`.
+    #[test]
+    fn default_policy_is_public_only() {
+        // No env var and no `set_allow_private_endpoints` call in this test
+        // binary's default state.
+        assert_eq!(webvh_host_policy(), HostPolicy::PublicOnly);
+    }
 }

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -266,7 +266,11 @@ futures-util = "0.3"
 # entry adds no new code when `tsp` is off (optional + default-features off).
 affinidi-messaging-sdk = { version = "0.24", optional = true, default-features = false }
 async-trait = "0.1"
-affinidi-tdk-common = "0.6"
+# 0.6.11 moves in lockstep with `affinidi-did-resolver-cache-sdk` 0.8.37: it is
+# the release built against that resolver, so a floor below it can resolve a
+# second, pre-host-policy resolver-cache copy into the graph through
+# `TDKSharedState`.
+affinidi-tdk-common = "0.6.11"
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio-util = { workspace = true, features = ["rt"] }
 base64 = { workspace = true }

--- a/vta-service/src/did_webvh.rs
+++ b/vta-service/src/did_webvh.rs
@@ -135,7 +135,12 @@ pub async fn run_create_did_webvh(
 
     // Build params and call the operations layer
     let auth = cli_super_admin();
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+    let did_resolver = DIDCacheClient::new(
+        DIDCacheConfigBuilder::default()
+            .with_host_policy(vta_sdk::resolver::webvh_host_policy())
+            .build(),
+    )
+    .await?;
     let no_bridge: Arc<crate::didcomm_bridge::DIDCommBridge> =
         Arc::new(crate::didcomm_bridge::DIDCommBridge::placeholder());
 

--- a/vta-service/src/messaging/readiness.rs
+++ b/vta-service/src/messaging/readiness.rs
@@ -236,7 +236,12 @@ fn apply_timeout_policy(
 /// entry (see `server::preload_self_did_document`) or a stale entry in the
 /// long-lived resolver can't mask the real state.
 async fn self_did_resolves(vta_did: &str, resolver_url: Option<&str>) -> bool {
-    let mut builder = DIDCacheConfigBuilder::default();
+    // Loopback/private hosts only when the operator opted in: the VTA's own DID
+    // is `did:webvh:{SCID}:localhost%3A3000` under `local-dev/*.toml`, and this
+    // probe deliberately bypasses the preloaded self-DID cache entry, so it is
+    // the first thing a local stack notices if the policy is wrong.
+    let mut builder =
+        DIDCacheConfigBuilder::default().with_host_policy(vta_sdk::resolver::webvh_host_policy());
     if let Some(url) = resolver_url {
         builder = builder.with_network_mode(url);
     }

--- a/vta-service/src/server.rs
+++ b/vta-service/src/server.rs
@@ -1728,7 +1728,8 @@ async fn init_auth(
 
     // 1. DID resolver (network mode if resolver_url is set, local mode otherwise)
     let resolver_config = {
-        let mut builder = DIDCacheConfigBuilder::default();
+        let mut builder = DIDCacheConfigBuilder::default()
+            .with_host_policy(vta_sdk::resolver::webvh_host_policy());
         if let Some(ref url) = config.resolver_url {
             info!(url = %url, "DID resolver using network mode (remote resolver)");
             builder = builder.with_network_mode(url);

--- a/vta-service/src/services_cli.rs
+++ b/vta-service/src/services_cli.rs
@@ -192,7 +192,12 @@ async fn build_offline_deps(
     // meant any non-plaintext backend failed with
     // "no seed found in external store" (#564).
     let seed_store = create_seed_store(&config)?;
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+    let did_resolver = DIDCacheClient::new(
+        DIDCacheConfigBuilder::default()
+            .with_host_policy(vta_sdk::resolver::webvh_host_policy())
+            .build(),
+    )
+    .await?;
     let didcomm_bridge = Arc::new(DIDCommBridge::placeholder());
     let telemetry: SharedTelemetrySink = Arc::new(RingBufferTelemetry::new());
     #[cfg(feature = "didcomm")]

--- a/vta-service/src/setup/from_toml.rs
+++ b/vta-service/src/setup/from_toml.rs
@@ -1764,7 +1764,12 @@ async fn create_simple_webvh_did(
         .to_string();
 
     let auth = cli_super_admin();
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+    let did_resolver = DIDCacheClient::new(
+        DIDCacheConfigBuilder::default()
+            .with_host_policy(vta_sdk::resolver::webvh_host_policy())
+            .build(),
+    )
+    .await?;
     let no_bridge: Arc<crate::didcomm_bridge::DIDCommBridge> =
         Arc::new(crate::didcomm_bridge::DIDCommBridge::placeholder());
 

--- a/vta-service/src/status.rs
+++ b/vta-service/src/status.rs
@@ -84,9 +84,13 @@ pub async fn run_status(config_path: Option<PathBuf>) -> Result<(), Box<dyn std:
     );
 
     // 2. DID resolver for resolution checks (created early, reused for contexts)
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
-        .await
-        .ok();
+    let did_resolver = DIDCacheClient::new(
+        DIDCacheConfigBuilder::default()
+            .with_host_policy(vta_sdk::resolver::webvh_host_policy())
+            .build(),
+    )
+    .await
+    .ok();
 
     // 3. VTA DID + resolution check → extract mediator DID from DIDCommMessaging
     let mut discovered_mediator: Option<String> = None;

--- a/vta-service/src/webvh_cli.rs
+++ b/vta-service/src/webvh_cli.rs
@@ -40,7 +40,12 @@ pub async fn run_add_server(
     let config = AppConfig::load(config_path)?;
     let cs = CliStore::open(&config).await?;
     let webvh_ks = cs.keyspace(crate::keyspaces::WEBVH)?;
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+    let did_resolver = DIDCacheClient::new(
+        DIDCacheConfigBuilder::default()
+            .with_host_policy(vta_sdk::resolver::webvh_host_policy())
+            .build(),
+    )
+    .await?;
 
     let auth = cli_super_admin();
     let result = operations::did_webvh::register_webvh_server(
@@ -197,7 +202,12 @@ pub async fn run_create_did(
         is_vta_identity: false,
     };
 
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+    let did_resolver = DIDCacheClient::new(
+        DIDCacheConfigBuilder::default()
+            .with_host_policy(vta_sdk::resolver::webvh_host_policy())
+            .build(),
+    )
+    .await?;
     let no_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
     // Offline CLI: no shared AppState, so create a local per-server
     // auth-lock registry for any daemon-REST authentication a publish
@@ -339,7 +349,12 @@ pub async fn run_delete_did(
         Arc::from(create_seed_store(&config)?);
 
     let auth = cli_super_admin();
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+    let did_resolver = DIDCacheClient::new(
+        DIDCacheConfigBuilder::default()
+            .with_host_policy(vta_sdk::resolver::webvh_host_policy())
+            .build(),
+    )
+    .await?;
     let no_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
     let auth_locks = crate::operations::did_webvh::WebvhAuthLocks::new();
     let deps = operations::did_webvh::WebvhDeps {
@@ -457,7 +472,12 @@ pub async fn run_edit_did(
     let contexts_ks = cs.keyspace(crate::keyspaces::CONTEXTS)?;
     let audit_ks = cs.keyspace(crate::keyspaces::AUDIT)?;
     let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks.clone());
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+    let did_resolver = DIDCacheClient::new(
+        DIDCacheConfigBuilder::default()
+            .with_host_policy(vta_sdk::resolver::webvh_host_policy())
+            .build(),
+    )
+    .await?;
     let didcomm_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
         Arc::from(create_seed_store(&config)?);
@@ -636,7 +656,12 @@ pub async fn run_register_did(
     let contexts_ks = cs.keyspace(crate::keyspaces::CONTEXTS)?;
     let audit_ks = cs.keyspace(crate::keyspaces::AUDIT)?;
     let audit: vta_audit::SharedAuditSink = vta_audit::shared_keyspace_sink(audit_ks.clone());
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build()).await?;
+    let did_resolver = DIDCacheClient::new(
+        DIDCacheConfigBuilder::default()
+            .with_host_policy(vta_sdk::resolver::webvh_host_policy())
+            .build(),
+    )
+    .await?;
     let didcomm_bridge: Arc<DIDCommBridge> = Arc::new(DIDCommBridge::placeholder());
     let seed_store: Arc<dyn crate::keys::seed_store::SeedStore> =
         Arc::from(create_seed_store(&config)?);

--- a/vtc-service/src/status.rs
+++ b/vtc-service/src/status.rs
@@ -78,9 +78,13 @@ pub async fn run_status(config_path: Option<PathBuf>) -> Result<(), Box<dyn std:
     );
 
     // 2. DID resolver for resolution checks
-    let did_resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
-        .await
-        .ok();
+    let did_resolver = DIDCacheClient::new(
+        DIDCacheConfigBuilder::default()
+            .with_host_policy(vta_sdk::resolver::webvh_host_policy())
+            .build(),
+    )
+    .await
+    .ok();
 
     // 3. VTC DID + resolution check → extract mediator DID from DIDCommMessaging
     let mut discovered_mediator: Option<String> = None;


### PR DESCRIPTION

Raises `affinidi-did-resolver-cache-sdk` to 0.8.37, which moves did:webvh
resolution onto `didwebvh-rs` 0.7 and closes a resolver-side SSRF that applied
to every crate in this workspace that resolves a DID.

## What was wrong

Through `didwebvh-rs` 0.6.1, `resolve()` rejected IP-literal hosts and nothing
else. `did:webvh:{SCID}:localhost%3A<port>` was fetched over plain `http://`,
and any other name was fetched from whatever address it resolved to. So a
did:webvh DID naming an internal host — or a public name whose A record points
at `169.254.169.254` — made the resolving process issue a GET inside its own
network, and the resulting error text distinguished "HTTP 404" from "connection
refused", which is enough to probe reachability. did:web had been guarded since
0.8.35; did:webvh had not, and it is reached from anything that resolves a DID:
the VTA and VTC servers, both CLIs, the readiness gate, status, and the mobile
core.

## What changes

`didwebvh-rs` 0.7 refuses `localhost`, `*.localhost`, `*.local`, `*.internal`,
`home.arpa` and single-label names before any request is made. On native
targets it also refuses, at connect time, a name whose DNS answer contains a
loopback, RFC 1918, carrier-grade-NAT (100.64.0.0/10), link-local, unique-local
or otherwise non-public address, and it connects only to addresses it checked.
Its default client refuses redirects and ignores `HTTP_PROXY` / `HTTPS_PROXY` /
`ALL_PROXY`, because a proxy resolves the target name itself and a DNS guard
would never see it. A refused DID fails with `BlockedHost`.

`DIDCacheConfigBuilder::with_host_policy` governs did:web and did:webvh
together. This branch threads one accessor —
`vta_sdk::resolver::webvh_host_policy()` — through every resolver-construction
site that a local stack exercises, so the policy is decided in one place
instead of at thirty `DIDCacheConfigBuilder::default()` calls.

## For operators

**Nothing to do, and nothing to turn on.** The new default is the secure one
and no production path is weakened. A VTA or VTC whose did:webvh hosts are
public resolves exactly as before.

Two cases need attention before rolling out:

- **did:webvh hosts on a private network.** A deployment whose DIDs genuinely
  name RFC 1918 space or `.internal` will stop resolving them. Set
  `VTA_ALLOW_PRIVATE_ENDPOINTS=1` for that deployment, having understood that
  it also lets did:web reach private hosts.
- **An egress HTTP proxy.** The default client no longer honours proxy
  environment variables, so a VTA that reached the internet only through a
  proxy will stop resolving did:webvh DIDs. That needs a network route rather
  than a setting.

Under TEE/Nitro, `resolver_url` points resolution at the sidecar, so the policy
applies in the sidecar's process — but a failed dispatch falls back to
resolving locally, so the setting still matters and is applied there too.

## For local development

`local-dev/vta-root-webvh-setup.toml` and
`local-dev/vta-pathful-webvh-setup.toml` publish `http://localhost:3000`, so
the VTA's own DID is `did:webvh:{SCID}:localhost%3A3000`. Resolving it is now
refused unless loopback is explicitly expected:

    export VTA_ALLOW_PRIVATE_ENDPOINTS=1

Export it for every command in a local stack, `setup` included. Without it
`setup`, `vta status`, `vta create-did-webvh` and the `vta webvh` commands fail
with `BlockedHost: localhost is not a public host (HostPolicy::PublicOnly)`,
and — the one failure that does not name itself — the mediator readiness gate
never goes green, because its self-resolution probe deliberately bypasses the
preloaded self-DID cache entry. Both config files now say this in their header.

This is the same switch as `--allow-private-endpoints` on `pnm` and `cnm`,
which already set it process-wide; it was reused rather than joined by a second
variable, because it answers one question: may this process reach hosts that
are not on the public internet? Note that under the private policy a
`localhost` DID is fetched over plain `http://`, which is the local-testing
special case and not something to carry into a deployment.

## Scope of the opt-in

Only self- and local-infrastructure resolution consults the policy. The sites
that resolve a **foreign** DID — witness DIDs, room hosts, mediator and
trust-registry DIDs, credential and ACL verification-method resolution, SIOP —
are deliberately left on `PublicOnly`. Those are the attacker-controlled inputs
the guard exists for, and they should refuse a private host even in local
development.

## Test

`vta-sdk`'s `resolver` module gains a test that asserts the default through
this workspace's own construction path rather than the dependency's API: a
`did:webvh` DID naming a counting TCP listener on 127.0.0.1 is refused with
`BlockedHost`, and the listener accepts **zero** connections. The
zero-connection assertion is the one that matters — "resolution failed" would
also hold for a fetch that happened and then failed to parse, and the request
itself is the leak. Loopback spelling variants (`LOCALHOST`, `localhost.`,
`svc.localhost`) and a metadata name are covered in the same test.

No existing test needed a policy opt-in: every webvh harness in the workspace
preseeds the resolver cache via `add_did_document` or uses `did:peer` /
`did:key`, so none of them was resolving a loopback DID over the network.

## Dependencies

- `affinidi-did-resolver-cache-sdk` 0.8.36 → 0.8.37, pinned to that minimum
  patch so a resolve cannot land back on a build without the policy.
- `didwebvh-rs` 0.6 → 0.7, `affinidi-did-web` 0.1.4 → 0.1.5,
  `affinidi-tdk-common` 0.6.10 → 0.6.11, `did-scid` 0.2.6 → 0.2.7, and
  `affinidi-net-guard` 0.1.0 added.
- `affinidi-messaging-mediator` 0.24.0 → 0.24.1. Not cosmetic: 0.24.0 requires
  `didwebvh-rs ^0.6`, so without it the lockfile carried a second,
  pre-policy `didwebvh-rs` 0.6.1 node, reached as a dev-dependency through
  `affinidi-messaging-test-mediator`. 0.24.1 requires `^0.7` and collapses it,
  leaving exactly one `didwebvh-rs` in the tree.
- `deploy/nitro/enclave-proxy` is a separate workspace with its own lockfile,
  and it resolves DIDs on the parent instance — outside the enclave — so it is
  exactly where a did:webvh DID naming an internal host would be fetched from.
  Its floor is raised to 0.8.37 the same way.

  Its lockfile change here is small: 21 lines added and 34 removed, adding
  `affinidi-net-guard` and dropping one duplicate `didwebvh-rs` node. That
  lockfile had been left a long way behind its own `"0.8"` requirement — at
  `affinidi-did-resolver-cache-sdk` 0.8.6 with `didwebvh-rs` 0.5.2 — but #1444
  (`chore(deps): bump the minor-and-patch group`) regenerated it on main while
  this branch was in progress. So the large cleanup of that tree, and the
  advisory reduction that came with it, belong to that PR and not to this one.
  Measured on the rebased branch, the advisory set is identical either side of
  this commit: RUSTSEC-2026-0190, -0204, -0221 and -0258 before and after.
  `cargo deny check bans advisories` passes on the root workspace.

No version fields and no changelog files are edited — release-plz owns both.
The `!` is deliberate: the resolution default changes for existing consumers,
and an unmarked behaviour change of this size would ship as a patch that
dependents take automatically.
