### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10907,7 +10907,7 @@ dependencies = [
 
 [[package]]
 name = "vta-persona"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -11424,7 +11424,7 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",

--- a/vta-persona/CHANGELOG.md
+++ b/vta-persona/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-persona-v0.3.2...vta-persona-v0.3.3) — 2026-09-12
+
+
 ## [0.3.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-persona-v0.3.0...vta-persona-v0.3.1) — 2026-09-09
 
 

--- a/vta-persona/Cargo.toml
+++ b/vta-persona/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-persona"
 description = "VTA persona store — the holder's own identity attributes, the profiles that project over them, the bindings that assign a profile to a persona DID, and the contacts peers disclose"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 # Published for the same reason vta-vault is: `vta-service` is published, and a
 # crate cannot go to crates.io without its whole dependency closure. Nothing

--- a/vti-rooms/CHANGELOG.md
+++ b/vti-rooms/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.2.1...vti-rooms-v0.2.2) — 2026-09-12
+
+
 ## [0.2.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.1.3...vti-rooms-v0.2.0) — 2026-09-09
 
 

--- a/vti-rooms/Cargo.toml
+++ b/vti-rooms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vti-rooms"
 description = "Data-room storage, wire types, and authorization — the parts of a room that are not a service"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `vti-common`: 0.18.3 -> 0.18.4
* `vti-rooms`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `vtc-client`: 0.6.0 -> 0.6.1
* `vta-cli-common`: 0.15.1 -> 0.15.2
* `cnm-cli`: 0.14.3 -> 0.14.4
* `pnm-cli`: 0.16.1 -> 0.16.2
* `vti-rooms-dtg`: 0.2.1 -> 0.2.2
* `vti-secrets`: 0.3.5 -> 0.3.6
* `vta-audit`: 0.3.6 -> 0.3.7
* `vta-config`: 0.4.6 -> 0.4.7
* `vta-keyspaces`: 0.2.7 -> 0.2.8
* `vta-keys`: 0.4.6 -> 0.4.7
* `vta-support`: 0.3.5 -> 0.3.6
* `vta-backup`: 0.3.6 -> 0.3.7
* `vta-persona`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `vta-policy`: 0.3.6 -> 0.3.7
* `vta-vault`: 0.5.6 -> 0.5.7
* `vta-sweepers`: 0.3.4 -> 0.3.5
* `vta-webvh`: 0.2.7 -> 0.2.8
* `vta-service`: 0.25.1 -> 0.26.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `vti-common`

<blockquote>

## [0.18.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.18.3...vti-common-v0.18.4) — 2026-09-10

### Added

- **audit**: Write the VTA's audit log as a hash chain ([#1420](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1420))

* feat(audit): write the VTA's audit log as a hash chain

  The sink writes envelopes through the shared writer rather than flat
  rows: each entry commits to its predecessor, and the actor and any
  DID-shaped target are committed under a keyed hash with the plaintext
  beside them, so an erasure can null the plaintext while the row stays
  correlatable and the chain still verifies.

  The chain opens with the creation of the key that chains it. The key is
  established on the first write — there is nothing to audit before a
  node can act, and a node cannot act before it has somewhere to record
  what it did — so the first entry is the record of that key coming into
  existence, committing to its id. A verifier reading from the start
  learns which key the entries after it are hashed under, from an entry
  hashed under that same key.

  The keyspace and the storage-key format are unchanged except for one
  addition. The seconds stay the leading field, because the retention
  sweep compares keys against a cutoff in that shape and a different
  leading field would make every chained row sort past every cutoff and
  never expire. The nanoseconds are new and are not optional: whole
  seconds put two entries written in the same second in uuid order, so a
  verifier reading in key order sees them out of chain order and reports
  a break in a chain that is intact — a false alarm indistinguishable
  from the thing it exists to detect. The tests found this rather than
  review.

  The read path now accepts both shapes. A reader that knows only one
  does not fail loudly; it skips what it cannot parse, so a reader that
  knew only the older shape would have reported a log that stops at the
  moment chaining began.

- **audit**: Give the VTA an audit key of its own ([#1419](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1419))

Two pieces, both inert until the sink uses them.

  ensure_initial_random establishes a key from the OS random source
  rather than from a seed. The key's job is to be a stable handle for
  actor and target identifiers — exist before the first write, stay
  retrievable while any envelope references it, be rotatable — and
  nothing about that requires it to be derivable. What derivation adds is
  a second copy of the key wherever the seed is, so a node whose recovery
  story is a mnemonic has an audit key that anyone holding the mnemonic
  can recompute. Since the commitment exists so an erasure can null the
  plaintext while the row stays correlatable, that makes the erasure
  reversible by brute force over the identifiers the node has seen.

  The cost is that the key is not regenerable, so the keyspace holding it
  joins the backed-up set. Without it a restored log still verifies as a
  chain and still says what happened, but no entry can be checked against
  a candidate identifier again.

  The keyspace is separate from the audit log because the two have
  opposite lifetimes: entries are erased when their retention expires,
  and a key must outlive every entry that references it. Neither cascades
  on a DID deletion, for the reason the audit log already does not.

- **audit**: Let the writer serve a keyspace that predates chaining ([#1413](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1413))

Two changes to AuditWriter, both needed before a VTA can use it and
  neither altering what a VTC does.

  The storage key becomes configurable. A keyspace that already holds
  rows has an ordering, and a writer that ignores it produces a log whose
  newest entry is not its last key — which breaks chain-head recovery and
  every reader that pages in key order. A VTA's audit keyspace is exactly
  that: it holds log:<zero-padded-epoch>:<uuid> rows, and those sort
  after an RFC 3339 timestamp. The default is unchanged, so a fresh
  keyspace needs nothing.

  Chain-head recovery walks back to the newest row that is an envelope
  rather than assuming the last row is one. Without it the first chained
  write against a VTA's keyspace fails, because the row beside it was
  written before the scheme existed. Deserialization is the test rather
  than the key, since the key format now belongs to the caller.

  Tests cover both: a pre-chain row does not stop the first chained write
  and the entry anchors at genesis, and a custom key still recovers the
  head across a restart so the second entry chains to the first.



### Changed

- **audit**: One construction point for the audit sink, and the prerequisites for chaining it ([#1412](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1412))

* refactor(audit): build the keyspace audit sink in one place

  The workspace built the same sink over the same keyspace in
  thirty-one places, including three times inside one function
  (run_create_did_webvh, which already had one in scope two hundred
  lines above the other two). Each was somewhere a later change to what
  a VTA's audit writes would have to be found and repeated.

  There is now one constructor, vta_audit::shared_keyspace_sink, and
  every caller goes through it. A server still takes its sink from
  AppState — that path was already correct, and its comment already said
  why. The factory is for the callers with no AppState to take one from:
  offline CLI commands, setup, sweepers and tests.

  No behaviour change. The next change to this subsystem — writing
  chained envelopes rather than flat rows — is now one edit instead of a
  search.
</blockquote>








## `vta-audit`

<blockquote>

## [0.3.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.3.6...vta-audit-v0.3.7) — 2026-09-10

### Added

- **audit**: Write the VTA's audit log as a hash chain ([#1420](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1420))

* feat(audit): write the VTA's audit log as a hash chain

  The sink writes envelopes through the shared writer rather than flat
  rows: each entry commits to its predecessor, and the actor and any
  DID-shaped target are committed under a keyed hash with the plaintext
  beside them, so an erasure can null the plaintext while the row stays
  correlatable and the chain still verifies.

  The chain opens with the creation of the key that chains it. The key is
  established on the first write — there is nothing to audit before a
  node can act, and a node cannot act before it has somewhere to record
  what it did — so the first entry is the record of that key coming into
  existence, committing to its id. A verifier reading from the start
  learns which key the entries after it are hashed under, from an entry
  hashed under that same key.

  The keyspace and the storage-key format are unchanged except for one
  addition. The seconds stay the leading field, because the retention
  sweep compares keys against a cutoff in that shape and a different
  leading field would make every chained row sort past every cutoff and
  never expire. The nanoseconds are new and are not optional: whole
  seconds put two entries written in the same second in uuid order, so a
  verifier reading in key order sees them out of chain order and reports
  a break in a chain that is intact — a false alarm indistinguishable
  from the thing it exists to detect. The tests found this rather than
  review.

  The read path now accepts both shapes. A reader that knows only one
  does not fail loudly; it skips what it cannot parse, so a reader that
  knew only the older shape would have reported a log that stops at the
  moment chaining began.



### Changed

- **audit**: One construction point for the audit sink, and the prerequisites for chaining it ([#1412](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1412))

* refactor(audit): build the keyspace audit sink in one place

  The workspace built the same sink over the same keyspace in
  thirty-one places, including three times inside one function
  (run_create_did_webvh, which already had one in scope two hundred
  lines above the other two). Each was somewhere a later change to what
  a VTA's audit writes would have to be found and repeated.

  There is now one constructor, vta_audit::shared_keyspace_sink, and
  every caller goes through it. A server still takes its sink from
  AppState — that path was already correct, and its comment already said
  why. The factory is for the callers with no AppState to take one from:
  offline CLI commands, setup, sweepers and tests.

  No behaviour change. The next change to this subsystem — writing
  chained envelopes rather than flat rows — is now one edit instead of a
  search.
</blockquote>


## `vta-keyspaces`

<blockquote>

## [0.2.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keyspaces-v0.2.7...vta-keyspaces-v0.2.8) — 2026-09-10

### Added

- **audit**: Give the VTA an audit key of its own ([#1419](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1419))

Two pieces, both inert until the sink uses them.

  ensure_initial_random establishes a key from the OS random source
  rather than from a seed. The key's job is to be a stable handle for
  actor and target identifiers — exist before the first write, stay
  retrievable while any envelope references it, be rotatable — and
  nothing about that requires it to be derivable. What derivation adds is
  a second copy of the key wherever the seed is, so a node whose recovery
  story is a mnemonic has an audit key that anyone holding the mnemonic
  can recompute. Since the commitment exists so an erasure can null the
  plaintext while the row stays correlatable, that makes the erasure
  reversible by brute force over the identifiers the node has seen.

  The cost is that the key is not regenerable, so the keyspace holding it
  joins the backed-up set. Without it a restored log still verifies as a
  chain and still says what happened, but no entry can be checked against
  a candidate identifier again.

  The keyspace is separate from the audit log because the two have
  opposite lifetimes: entries are erased when their retention expires,
  and a key must outlive every entry that references it. Neither cascades
  on a DID deletion, for the reason the audit log already does not.
</blockquote>







## `vta-sweepers`

<blockquote>

## [0.3.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sweepers-v0.3.4...vta-sweepers-v0.3.5) — 2026-09-10

### Changed

- **audit**: One construction point for the audit sink, and the prerequisites for chaining it ([#1412](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1412))

* refactor(audit): build the keyspace audit sink in one place

  The workspace built the same sink over the same keyspace in
  thirty-one places, including three times inside one function
  (run_create_did_webvh, which already had one in scope two hundred
  lines above the other two). Each was somewhere a later change to what
  a VTA's audit writes would have to be found and repeated.

  There is now one constructor, vta_audit::shared_keyspace_sink, and
  every caller goes through it. A server still takes its sink from
  AppState — that path was already correct, and its comment already said
  why. The factory is for the callers with no AppState to take one from:
  offline CLI commands, setup, sweepers and tests.

  No behaviour change. The next change to this subsystem — writing
  chained envelopes rather than flat rows — is now one edit instead of a
  search.
</blockquote>


## `vta-service`

<blockquote>

## [0.26.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.25.1...vta-service-v0.26.0) — 2026-09-10

### Added

- **audit**: Write the VTA's audit log as a hash chain ([#1420](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1420))

* feat(audit): write the VTA's audit log as a hash chain

  The sink writes envelopes through the shared writer rather than flat
  rows: each entry commits to its predecessor, and the actor and any
  DID-shaped target are committed under a keyed hash with the plaintext
  beside them, so an erasure can null the plaintext while the row stays
  correlatable and the chain still verifies.

  The chain opens with the creation of the key that chains it. The key is
  established on the first write — there is nothing to audit before a
  node can act, and a node cannot act before it has somewhere to record
  what it did — so the first entry is the record of that key coming into
  existence, committing to its id. A verifier reading from the start
  learns which key the entries after it are hashed under, from an entry
  hashed under that same key.

  The keyspace and the storage-key format are unchanged except for one
  addition. The seconds stay the leading field, because the retention
  sweep compares keys against a cutoff in that shape and a different
  leading field would make every chained row sort past every cutoff and
  never expire. The nanoseconds are new and are not optional: whole
  seconds put two entries written in the same second in uuid order, so a
  verifier reading in key order sees them out of chain order and reports
  a break in a chain that is intact — a false alarm indistinguishable
  from the thing it exists to detect. The tests found this rather than
  review.

  The read path now accepts both shapes. A reader that knows only one
  does not fail loudly; it skips what it cannot parse, so a reader that
  knew only the older shape would have reported a log that stops at the
  moment chaining began.



### Changed

- **audit**: One construction point for the audit sink, and the prerequisites for chaining it ([#1412](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1412))

* refactor(audit): build the keyspace audit sink in one place

  The workspace built the same sink over the same keyspace in
  thirty-one places, including three times inside one function
  (run_create_did_webvh, which already had one in scope two hundred
  lines above the other two). Each was somewhere a later change to what
  a VTA's audit writes would have to be found and repeated.

  There is now one constructor, vta_audit::shared_keyspace_sink, and
  every caller goes through it. A server still takes its sink from
  AppState — that path was already correct, and its comment already said
  why. The factory is for the callers with no AppState to take one from:
  offline CLI commands, setup, sweepers and tests.

  No behaviour change. The next change to this subsystem — writing
  chained envelopes rather than flat rows — is now one edit instead of a
  search.



### Security

- **keys**: Domain-separate the opaque signing oracle ([#1417](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1417))

The generic signing operation signs an octet string a caller supplies,
  under a key the caller names. Authorization bounds which key signs — by
  context, by the context's signable-keys policy, by the entry's own key
  narrowing — and says nothing about what the bytes will be taken to
  mean. A caller authorized to sign for one purpose could obtain a
  signature that verifies as something else: an assertion in another
  protocol, a token, a proof over a document the principal never saw.

  Payloads the VTA cannot parse are now framed under a domain tag before
  signing, so the signature verifies as a VTA opaque-signing payload and
  as nothing else. This does not make signing arbitrary bytes safe; it
  makes the result unusable outside the domain it was requested in.

  The domain is an argument rather than a blanket prefix because one
  caller must not be framed: the data-integrity proof signer builds bytes
  whose meaning its own specification has already established, and
  framing those again would produce a proof a conforming verifier
  rejects. Each call site now states which case it is in, and the two are
  not interchangeable.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).