### PR TITLE
chore(deps): keep rand out of Dependabot's sweep while rPGP needs 0.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,14 @@ updates:
       - dependency-name: "vta-*"
       - dependency-name: "vti-*"
       - dependency-name: "vtc-*"
+      # `cnm-cli`'s dev-dependency, held at 0.8 by rPGP. `pgp` 0.20 — the
+      # latest release — takes an `R: CryptoRng + Rng` from the rand 0.8 trait
+      # set for key generation, and the bootstrap tests hand it a seeded
+      # `StdRng` so the generated web of trust has stable fingerprints. A 0.10
+      # bump was proposed (#1445) and cannot build: `StdRng: rand_core::
+      # CryptoRng is not satisfied`. The workspace itself is already on 0.10,
+      # and that copy is unaffected. Lift this when the OpenPGP stack moves.
+      - dependency-name: "rand"
 
   # ── GitHub Actions ────────────────────────────────────────────────────
   # Every `uses:` in this repo is a full 40-hex commit SHA with the version in

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -54,6 +54,11 @@ tracing-subscriber = { workspace = true }
 # The bootstrap tests generate a small web of trust with rPGP, whose key
 # generation takes a rand 0.8 RNG (the workspace is on 0.10). A seeded StdRng
 # keeps the keys, and so the fingerprints, the same on every run.
+#
+# Dependabot proposed 0.10 (#1445); it does not build, because `pgp` wants the
+# rand 0.8 trait set (`StdRng: rand_core::CryptoRng is not satisfied`). `rand`
+# is in Dependabot's ignore list for that reason; lift both together when the
+# OpenPGP stack releases on a newer rand.
 rand = "0.8"
 tempfile = "3"
 


### PR DESCRIPTION
**#1445 cannot be merged.** It bumps `cnm-cli`'s dev-dependency `rand` 0.8 → 0.10, and the PGP bootstrap tests fail to compile: *the trait bound `StdRng: rand_core::CryptoRng` is not satisfied*. `pgp` 0.20 — the latest release, from June — takes an `R: CryptoRng + Rng` from the **rand 0.8** trait set for key generation, and those tests hand it a seeded `StdRng` so the generated web of trust keeps stable fingerprints.

There is nothing newer to move to: every published `pgp` version declares `rand ^0.8`.

**This PR** adds `rand` to the cargo `ignore:` list and records why, both there and beside the dev-dependency, so the bump does not come back each week. No code or lockfile changes — `cargo metadata --locked` is unchanged.

**Scope:** only `cnm-cli`'s dev-dependency is pinned. The workspace's own `rand` is already 0.10 and is untouched.

**Suggest closing #1445** once this lands.

**Unrelated, for whoever picks them up:** #1446 (`chacha20poly1305` 0.10 → 0.11) fails with 8 compile errors in `vti-rooms` plus a `hybrid_array::Array::from_slice` deprecation; #1447 (`jsonschema`) is failing for a reason I haven't diagnosed.