### PR TITLE
chore(deps): hold rand at 0.8 in Dependabot until pgp supports rand 0.9+

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,23 @@ updates:
       - dependency-name: "vta-*"
       - dependency-name: "vti-*"
       - dependency-name: "vtc-*"
+      # `rand` is held at 0.8 *for one crate*: cnm-cli's PGP test helpers.
+      # `pgp` 0.20 takes `rand_core` 0.6 RNGs in `SecretKeyParams::generate`,
+      # and a 0.9+ `StdRng` does not implement those traits, so the bump cannot
+      # compile — see the comment on `rand` in cnm-cli/Cargo.toml. Dependabot
+      # proposed 0.8.8 -> 0.10.2 regardless (#1445, closed).
+      #
+      # The cost of this entry is that it is repo-wide: the workspace root is
+      # already on rand 0.10, and this freezes that too, because both manifests
+      # live under the same update config and Dependabot cannot scope an ignore
+      # to one of them. Patch updates are deliberately left flowing, so a
+      # 0.8.x or 0.10.x advisory still arrives.
+      #
+      # Remove this entry once `pgp` supports rand 0.9+.
+      - dependency-name: "rand"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   # ── GitHub Actions ────────────────────────────────────────────────────
   # Every `uses:` in this repo is a full 40-hex commit SHA with the version in


### PR DESCRIPTION
## Why

`#1445` (rand 0.8.8 → 0.10.2) was closed because it cannot compile. Nothing prevents Dependabot proposing it again next week, so this adds the `ignore` entry that makes the closure stick.

The pin it was undoing is deliberate and already documented in `cnm-cli/Cargo.toml`:

```toml
# generation takes a rand 0.8 RNG (the workspace is on 0.10). A seeded StdRng
rand = "0.8"
```

`pgp` 0.20 takes `rand_core` 0.6 RNGs in `SecretKeyParams::generate`, and a rand 0.9+ `StdRng` does not implement those traits:

```
error[E0277]: the trait bound `rand::prelude::StdRng: rand_core::CryptoRng` is not satisfied
note: required by a bound in `pgp::composed::SecretKeyParams::generate`
```

That is why `#1445` was red on Clippy, Feature combos and Test (workspace) while Check and MSRV passed.

## What this does

Ignores **major and minor** rand updates, which is what holds 0.8.x (for a `0.x` crate, Dependabot treats `0.8 → 0.9` and `0.8 → 0.10` as minor). **Patch updates are left flowing**, so a 0.8.x advisory still reaches you.

## The tradeoff, stated plainly

The entry is repo-wide. The workspace root is already on `rand = "0.10"`, and this freezes that too, because both manifests live under the same cargo update config and Dependabot cannot scope an `ignore` to one directory within it. Only `cnm-cli` actually needs the hold.

I judged that acceptable because rand 0.10 is current and patch updates still flow, but it is a real cost and the comment in the file says so, along with the condition for removing the entry: **`pgp` supporting rand 0.9+**.

`/deploy/nitro/enclave-proxy` has its own cargo config and is deliberately left alone — it has no `pgp`, and its `rand` is a transitive 0.9.4 that should keep moving.

## Verification

`.github/dependabot.yml` parses as YAML and the root cargo config carries exactly one `rand` ignore entry with both update-types. No other config is modified.
