### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2631,7 +2631,7 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cnm-cli"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "chrono",
@@ -7519,7 +7519,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnm-cli"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-resolver-cache-sdk",
@@ -10810,7 +10810,7 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10829,7 +10829,7 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
@@ -10859,7 +10859,7 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -10885,7 +10885,7 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -10918,7 +10918,7 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -11021,7 +11021,7 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "hex",
  "multibase",
@@ -11041,7 +11041,7 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -11109,7 +11109,7 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-bbs",
@@ -11216,7 +11216,7 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -11252,7 +11252,7 @@ dependencies = [
 
 [[package]]
 name = "vta-tee"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "aes 0.9.3",
  "aes-gcm 0.11.1",
@@ -11287,7 +11287,7 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "affinidi-bbs",
  "affinidi-crypto",
@@ -11321,7 +11321,7 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -11342,7 +11342,7 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "reqwest",
@@ -11444,7 +11444,7 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -11519,7 +11519,7 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -11546,7 +11546,7 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms-dtg"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -11591,7 +11591,7 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "aws-config",
  "aws-sdk-secretsmanager",

--- a/cnm-cli/CHANGELOG.md
+++ b/cnm-cli/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.15.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.14.4...cnm-cli-v0.15.0) — 2026-09-12
+
+
+### Security
+
+- **resolver**: Refuse did:webvh resolution to non-public hosts by default ([#1448](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1448))
+
+
 ## [0.14.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.14.3...cnm-cli-v0.14.4) — 2026-09-10
 
 

--- a/cnm-cli/Cargo.toml
+++ b/cnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cnm-cli"
 description = "CLI Tool for Verified Trust Agents operating in Verified Trust Communities"
-version = "0.14.4"
+version = "0.15.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ config-session = ["vta-sdk/config-session"]
 azure-secrets = ["vta-sdk/azure-secrets"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = ["session", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = ["session", "crypto-provider", "acl-setup"] }
 # `agent-names` powers the global `--resolve-agent-names` flag; without it
 # the flag parses but can never resolve anything.
 vta-cli-common = { path = "../vta-cli-common", version = "0.15", features = [

--- a/didcomm-test/Cargo.toml
+++ b/didcomm-test/Cargo.toml
@@ -13,7 +13,7 @@ name = "didcomm-test"
 path = "src/main.rs"
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = ["didcomm", "crypto-provider"] }
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = ["didcomm", "crypto-provider"] }
 affinidi-tdk = { workspace = true }
 affinidi-did-resolver-cache-sdk = { workspace = true }
 tokio = { workspace = true }

--- a/pnm-cli/CHANGELOG.md
+++ b/pnm-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.16.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.16.2...pnm-cli-v0.16.3) — 2026-09-12
+
+
 ## [0.16.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/pnm-cli-v0.16.1...pnm-cli-v0.16.2) — 2026-09-10
 
 

--- a/pnm-cli/Cargo.toml
+++ b/pnm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pnm-cli"
 description = "CLI Tool for managing a personal Verifiable Trust Agent"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ azure-secrets = ["vta-sdk/azure-secrets"]
 tsp = ["vta-sdk/tsp"]
 
 [dependencies]
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = ["session", "sealed-transfer", "attest-verify", "provision-integration", "crypto-provider", "acl-setup"] }
 affinidi-crypto = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }

--- a/room-host/Cargo.toml
+++ b/room-host/Cargo.toml
@@ -63,7 +63,7 @@ affinidi-messaging-core = { workspace = true, optional = true }
 vti-secrets = { path = "../vti-secrets", version = "0.3", optional = true }
 # The session store behind `onboarding` — which backend is an operator's choice,
 # exactly as `[secrets]` is.
-vta-sdk = { path = "../vta-sdk", version = "0.37", optional = true }
+vta-sdk = { path = "../vta-sdk", version = "0.38", optional = true }
 # Reading the `[secrets]` table out of a config file.
 toml = { workspace = true, optional = true }
 affinidi-secrets-resolver = { workspace = true, optional = true }

--- a/vta-audit/CHANGELOG.md
+++ b/vta-audit/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.3.7...vta-audit-v0.3.8) — 2026-09-12
+
+
 ## [0.3.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-audit-v0.3.6...vta-audit-v0.3.7) — 2026-09-10
 
 

--- a/vta-audit/Cargo.toml
+++ b/vta-audit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-audit"
 description = "Structured audit logging for the VTA — the `audit!` tracing macro plus the audit-keyspace persistence helpers"
 readme = "README.md"
-version = "0.3.7"
+version = "0.3.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -21,7 +21,7 @@ repository.workspace = true
 
 [dependencies]
 vti-common = { path = "../vti-common", version = "0.18" }
-vta-sdk = { path = "../vta-sdk", version = "0.37" }
+vta-sdk = { path = "../vta-sdk", version = "0.38" }
 async-trait = "0.1"
 chrono = { workspace = true }
 hex = { workspace = true }

--- a/vta-backup/CHANGELOG.md
+++ b/vta-backup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.3.7...vta-backup-v0.3.8) — 2026-09-12
+
+
 ## [0.3.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-backup-v0.3.6...vta-backup-v0.3.7) — 2026-09-10
 
 

--- a/vta-backup/Cargo.toml
+++ b/vta-backup/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-backup"
 description = "VTA backup/restore subsystem — encrypted full-state export/import, the sealed backup-bundle store, and its TTL sweeper"
 readme = "README.md"
-version = "0.3.7"
+version = "0.3.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -32,7 +32,7 @@ vti-common = { path = "../vti-common", version = "0.18" }
 # a re-export aes-gcm 0.11 dropped; this crate always needed a CSPRNG of its
 # own and was borrowing one from its cipher.
 rand = { workspace = true }
-vta-sdk = { path = "../vta-sdk", version = "0.37" }
+vta-sdk = { path = "../vta-sdk", version = "0.38" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-keys = { path = "../vta-keys", version = "0.4" }
 vta-config = { path = "../vta-config", version = "0.4" }

--- a/vta-cli-common/CHANGELOG.md
+++ b/vta-cli-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.15.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.15.2...vta-cli-common-v0.15.3) — 2026-09-12
+
+
 ## [0.15.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-cli-common-v0.15.1...vta-cli-common-v0.15.2) — 2026-09-10
 
 

--- a/vta-cli-common/Cargo.toml
+++ b/vta-cli-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-cli-common"
 description = "Shared CLI command handlers and rendering helpers for VTA CLIs"
 readme = "README.md"
-version = "0.15.2"
+version = "0.15.3"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ agent-names = ["vta-sdk/agent-names"]
 [dependencies]
 # `time` for the consent loop's bounded wait between polls.
 tokio = { workspace = true, features = ["time"] }
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = [
   "client",
   "sealed-transfer",
   "provision-integration",

--- a/vta-config/CHANGELOG.md
+++ b/vta-config/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.4.7...vta-config-v0.4.8) — 2026-09-12
+
+
 ## [0.4.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-config-v0.4.6...vta-config-v0.4.7) — 2026-09-10
 
 

--- a/vta-config/Cargo.toml
+++ b/vta-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-config"
 description = "VTA configuration types — the `AppConfig` TOML shape and its sub-configs, composing the vti-common and vti-secrets config types"
 readme = "README.md"
-version = "0.4.7"
+version = "0.4.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -30,7 +30,7 @@ vti-common = { path = "../vti-common", version = "0.18" }
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
 # Types only: the declarative approvals rule shape, so a config seed and the
 # runtime row are the same struct rather than two that must be kept in step.
-vta-sdk = { path = "../vta-sdk", version = "0.37", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.38", default-features = false }
 serde = { workspace = true }
 toml = { workspace = true }
 serde_ignored = { workspace = true }

--- a/vta-enclave/Cargo.toml
+++ b/vta-enclave/Cargo.toml
@@ -34,7 +34,7 @@ vsock-log = ["dep:tokio-vsock"]
 tenant-overlay = ["dep:vta-tee", "vta-tee/tenant-overlay"]
 
 [dependencies]
-vta-service = { path = "../vta-service", version = "0.26", default-features = false, features = ["tee"] }
+vta-service = { path = "../vta-service", version = "0.27", default-features = false, features = ["tee"] }
 vti-common = { path = "../vti-common", version = "0.18", features = ["encryption"] }
 # Direct dep only for the `tenant-overlay` fetch entry point; the rest of the
 # TEE bootstrap is reached through `vta_service::tee`. Optional so a baked build

--- a/vta-keys/CHANGELOG.md
+++ b/vta-keys/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.4.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.4.7...vta-keys-v0.4.8) — 2026-09-12
+
+
 ## [0.4.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-keys-v0.4.6...vta-keys-v0.4.7) — 2026-09-10
 
 

--- a/vta-keys/Cargo.toml
+++ b/vta-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-keys"
 description = "VTA key management — master-seed storage, BIP-32 key derivation, key wrapping, and the seed-store backend selection"
 readme = "README.md"
-version = "0.4.7"
+version = "0.4.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -38,7 +38,7 @@ vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vta-config = { path = "../vta-config", version = "0.4" }
 vti-common = { path = "../vti-common", version = "0.18" }
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = ["sealed-transfer"] }
 affinidi-tdk = { workspace = true }
 affinidi-crypto = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/vta-mcp/Cargo.toml
+++ b/vta-mcp/Cargo.toml
@@ -24,7 +24,7 @@ config-session = ["vta-sdk/config-session"]
 # accept-all on connect (`vta_sdk::acl_setup::set_client_acl_on_connection`).
 # Without it the MCP server's ACL is never configured and the mediator silently
 # drops message types it was not told to accept.
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = ["client", "session", "sealed-transfer", "didcomm", "vp", "crypto-provider", "acl-setup"] }
 # `elicitation` is what lets the bridge put a destructive operation back in
 # front of a human. An MCP host approves a *tool*; once `vta_call` is approved,
 # every Trust Task URI rides that one approval, so per-operation consent has to

--- a/vta-mobile-core/Cargo.toml
+++ b/vta-mobile-core/Cargo.toml
@@ -72,7 +72,7 @@ affinidi-messaging-didcomm = "0.15"
 # lookup the approval sheets render through. Costs a DID resolution plus an
 # outbound fetch per claimed name, which is why the app resolves lazily and
 # caches; see `crate::display_name`.
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = [
   "session",
   "tsp",
   "agent-names",

--- a/vta-policy/CHANGELOG.md
+++ b/vta-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.3.7...vta-policy-v0.3.8) — 2026-09-12
+
+
 ## [0.3.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-policy-v0.3.6...vta-policy-v0.3.7) — 2026-09-10
 
 

--- a/vta-policy/Cargo.toml
+++ b/vta-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-policy"
 description = "VTA policy subsystem — the regorus (Rego) engine, the default policy bundle, consent model, and decision evaluators"
 readme = "README.md"
-version = "0.3.7"
+version = "0.3.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -25,7 +25,7 @@ vta-config = { path = "../vta-config", version = "0.4" }
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 # Types only (default features off): the declarative approvals model + its Rego
 # synthesizer, shared with the CLI so both sides derive the same module.
-vta-sdk = { path = "../vta-sdk", version = "0.37", default-features = false }
+vta-sdk = { path = "../vta-sdk", version = "0.38", default-features = false }
 regorus = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vta-sdk/CHANGELOG.md
+++ b/vta-sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.38.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.37.0...vta-sdk-v0.38.0) — 2026-09-12
+
+
+### Security
+
+- **resolver**: Refuse did:webvh resolution to non-public hosts by default ([#1448](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1448))
+
+
 ## [0.37.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.36.0...vta-sdk-v0.37.0) — 2026-09-10
 
 

--- a/vta-sdk/Cargo.toml
+++ b/vta-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-sdk"
 description = "SDK for Verifiable Trust Agents operating in Verifiable Trust Communities"
 readme = "README.md"
-version = "0.37.0"
+version = "0.38.0"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true

--- a/vta-service/CHANGELOG.md
+++ b/vta-service/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.27.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.26.0...vta-service-v0.27.0) — 2026-09-12
+
+
+### Security
+
+- **resolver**: Refuse did:webvh resolution to non-public hosts by default ([#1448](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1448))
+
+
 ## [0.26.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.25.1...vta-service-v0.26.0) — 2026-09-10
 
 

--- a/vta-service/Cargo.toml
+++ b/vta-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vta-service"
 description = "Service for Verifiable Trust Agents operating in Verifiable Trust Communities"
-version = "0.26.0"
+version = "0.27.0"
 edition.workspace = true
 # Published for one reason: `openvtc-core` dev-depends on it for
 # `test_support::MockVta`, the in-process VTA its end-to-end tests run against.
@@ -193,7 +193,7 @@ vta-policy = { path = "../vta-policy", version = "0.3" }
 # extracted to its own crate and re-exported as crate::{webvh_store,
 # webvh_client, webvh_auth} behind this crate's `webvh` feature.
 vta-webvh = { path = "../vta-webvh", version = "0.2", optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = ["didcomm", "sealed-transfer", "provision-integration", "openapi", "crypto-provider", "acl-setup"] }
 # DID-VM-resolved WebAuthn assertion verifier — drives the new
 # `vta/auth/passkey-login-{start,finish}/1.0` trust-task handlers.
 # Distinct from `webauthn-rs` (which drives the passkey *enrolment*
@@ -397,7 +397,7 @@ vta-service = { path = ".", features = ["test-support", "config-seed"] }
 # here rather than from `vta-sdk`'s own tests — the workspace patches `vta-sdk`
 # onto itself, so `-p vta-sdk --features test-loopback` leaves the built unit
 # Fresh and the feature never reaches the compiler.
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = [
   "provision-client",
   "test-loopback",
 ] }

--- a/vta-support/CHANGELOG.md
+++ b/vta-support/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.3.6...vta-support-v0.3.7) — 2026-09-12
+
+
 ## [0.3.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-support-v0.3.5...vta-support-v0.3.6) — 2026-09-10
 
 

--- a/vta-support/Cargo.toml
+++ b/vta-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-support"
 description = "Shared mid-layer VTA services — trust-context storage, the sealed-transfer seal helper, and the sealed-bootstrap nonce store"
 readme = "README.md"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -30,7 +30,7 @@ vta-config = { path = "../vta-config", version = "0.4" }
 # does not exist and the tarball fails to compile. That is what broke the
 # publish run for 0.2.0.
 vti-common = { path = "../vti-common", version = "0.18", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = ["sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = ["sealed-transfer"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/vta-tee/CHANGELOG.md
+++ b/vta-tee/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.2.4...vta-tee-v0.2.5) — 2026-09-12
+
+
 ## [0.2.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-tee-v0.2.3...vta-tee-v0.2.4) — 2026-09-07
 
 

--- a/vta-tee/Cargo.toml
+++ b/vta-tee/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-tee"
 description = "VTA TEE bootstrap — Nitro/SEV-SNP attestation providers, KMS attest/decrypt + storage-key derivation, the anchor MAC, and first-boot DID autogen"
 readme = "README.md"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own

--- a/vta-vault/CHANGELOG.md
+++ b/vta-vault/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.5.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.5.7...vta-vault-v0.5.8) — 2026-09-12
+
+
 ## [0.5.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-vault-v0.5.6...vta-vault-v0.5.7) — 2026-09-10
 
 

--- a/vta-vault/Cargo.toml
+++ b/vta-vault/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-vault"
 description = "VTA holder credential vault — storage, query, receive/verify, present, and status refresh for credentials a holder stores on a VTA"
 readme = "README.md"
-version = "0.5.7"
+version = "0.5.8"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -34,7 +34,7 @@ webvh = ["dep:reqwest", "vta-sdk/client"]
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vti-common = { path = "../vti-common", version = "0.18", features = ["encryption"] }
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = ["didcomm", "sealed-transfer"] }
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = ["didcomm", "sealed-transfer"] }
 affinidi-crypto = { workspace = true }
 affinidi-secrets-resolver = { workspace = true }
 affinidi-data-integrity = { workspace = true }

--- a/vta-webvh/CHANGELOG.md
+++ b/vta-webvh/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.9](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.2.8...vta-webvh-v0.2.9) — 2026-09-12
+
+
 ## [0.2.8](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-webvh-v0.2.7...vta-webvh-v0.2.8) — 2026-09-10
 
 

--- a/vta-webvh/Cargo.toml
+++ b/vta-webvh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vta-webvh"
 description = "WebVH hosting infrastructure for the VTA — the DID-record store, the HTTP client to a did:webvh hosting server, and its DID-auth handshake"
 readme = "README.md"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 # Published, because `vta-service` is — and a crate cannot go to crates.io
 # without its whole dependency closure there too. Not published for its own
@@ -22,7 +22,7 @@ repository.workspace = true
 [dependencies]
 vta-keyspaces = { path = "../vta-keyspaces", version = "0.2" }
 vti-common = { path = "../vti-common", version = "0.18" }
-vta-sdk = { path = "../vta-sdk", version = "0.37" }
+vta-sdk = { path = "../vta-sdk", version = "0.38" }
 affinidi-tdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vtc-client/CHANGELOG.md
+++ b/vtc-client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.6.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.6.1...vtc-client-v0.6.2) — 2026-09-12
+
+
 ## [0.6.1](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vtc-client-v0.6.0...vtc-client-v0.6.1) — 2026-09-10
 
 

--- a/vtc-client/Cargo.toml
+++ b/vtc-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtc-client"
 description = "Client SDK for Verifiable Trust Communities (VTC) — auth, members, join, removal, policies"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -38,7 +38,7 @@ tsp = ["didcomm", "vta-sdk/tsp"]
 # Reuses the VTA SDK's challenge-response auth (audience-agnostic) and the
 # published join-request protocol types. `session` gates `auth_light` +
 # `protocols`.
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = ["session"] }
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = ["session"] }
 
 # The room's wire types, and — under the `mls` feature — its group-key and
 # sealing layers, which this crate re-exports rather than owning. A VTA needs

--- a/vtc-service/Cargo.toml
+++ b/vtc-service/Cargo.toml
@@ -136,7 +136,7 @@ vti-common = { path = "../vti-common", version = "0.18", features = [
 # factory + `*SecretStore` names are a thin facade over these). Per-backend
 # features are activated by this crate's matching features above.
 vti-secrets = { path = "../vti-secrets", version = "0.3" }
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = [
   "didcomm",
   "session",
   "config-session",

--- a/vti-common/CHANGELOG.md
+++ b/vti-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.18.5](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.18.4...vti-common-v0.18.5) — 2026-09-12
+
+
 ## [0.18.4](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-common-v0.18.3...vti-common-v0.18.4) — 2026-09-10
 
 

--- a/vti-common/Cargo.toml
+++ b/vti-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-common"
 description = "Shared server-side infrastructure for VTA and VTC services"
 readme = "README.md"
-version = "0.18.4"
+version = "0.18.5"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -48,7 +48,7 @@ openapi = ["dep:utoipa", "dep:utoipa-axum"]
 # `default-features = false` skips the optional client transports
 # (didcomm, sealed-transfer, etc.); we only consume the type
 # definitions in the default feature set.
-vta-sdk = { path = "../vta-sdk", version = "0.37", default-features = false, features = [
+vta-sdk = { path = "../vta-sdk", version = "0.38", default-features = false, features = [
   # The Trust-Task proof verifier lives there now; this crate re-exports it.
   "proof-verify",
 ] }

--- a/vti-rooms-dtg/CHANGELOG.md
+++ b/vti-rooms-dtg/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-dtg-v0.2.2...vti-rooms-dtg-v0.2.3) — 2026-09-12
+
+
 ## [0.2.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-dtg-v0.2.1...vti-rooms-dtg-v0.2.2) — 2026-09-10
 
 

--- a/vti-rooms-dtg/Cargo.toml
+++ b/vti-rooms-dtg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vti-rooms-dtg"
 description = "The DTG-credential chain verifier for data rooms"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -45,7 +45,7 @@ tracing = { workspace = true }
 ed25519-dalek = { workspace = true, optional = true }
 getrandom = { version = "0.4", optional = true }
 multibase = { workspace = true, optional = true }
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = ["didcomm"], optional = true }
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = ["didcomm"], optional = true }
 affinidi-tdk = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/vti-rooms/CHANGELOG.md
+++ b/vti-rooms/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.2.3](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.2.2...vti-rooms-v0.2.3) — 2026-09-12
+
+
 ## [0.2.2](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-rooms-v0.2.1...vti-rooms-v0.2.2) — 2026-09-12
 
 

--- a/vti-rooms/Cargo.toml
+++ b/vti-rooms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vti-rooms"
 description = "Data-room storage, wire types, and authorization — the parts of a room that are not a service"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/vti-secrets/CHANGELOG.md
+++ b/vti-secrets/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Notable changes to the published crates. Generated from conventional commits by
 [git-cliff](https://git-cliff.org) when a release is cut — do not edit by hand.
+## [0.3.7](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.3.6...vti-secrets-v0.3.7) — 2026-09-12
+
+
 ## [0.3.6](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vti-secrets-v0.3.5...vti-secrets-v0.3.6) — 2026-09-10
 
 

--- a/vti-secrets/Cargo.toml
+++ b/vti-secrets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vti-secrets"
 description = "Pluggable secret-store backends + integration onboarding flow for Verifiable Trust Infrastructure"
 readme = "README.md"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 publish.workspace = true
 authors.workspace = true
@@ -56,7 +56,7 @@ tokio = { workspace = true }
 zeroize = { version = "1" }
 
 # Onboarding feature: the SDK session/auth state machine + local did:key mint.
-vta-sdk = { path = "../vta-sdk", version = "0.37", features = [
+vta-sdk = { path = "../vta-sdk", version = "0.38", features = [
   "session",
 ], optional = true }
 ed25519-dalek = { workspace = true, optional = true }


### PR DESCRIPTION



## 🤖 New release

* `vta-sdk`: 0.37.0 -> 0.38.0 (✓ API compatible changes)
* `vti-common`: 0.18.4 -> 0.18.5 (✓ API compatible changes)
* `vti-rooms`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `cnm-cli`: 0.14.4 -> 0.15.0
* `pnm-cli`: 0.16.2 -> 0.16.3
* `vta-vault`: 0.5.7 -> 0.5.8
* `vta-tee`: 0.2.4 -> 0.2.5
* `vta-service`: 0.26.0 -> 0.27.0 (✓ API compatible changes)
* `vtc-client`: 0.6.1 -> 0.6.2
* `vta-cli-common`: 0.15.2 -> 0.15.3
* `vti-rooms-dtg`: 0.2.2 -> 0.2.3
* `vti-secrets`: 0.3.6 -> 0.3.7
* `vta-audit`: 0.3.7 -> 0.3.8
* `vta-config`: 0.4.7 -> 0.4.8
* `vta-keys`: 0.4.7 -> 0.4.8
* `vta-support`: 0.3.6 -> 0.3.7
* `vta-backup`: 0.3.7 -> 0.3.8
* `vta-policy`: 0.3.7 -> 0.3.8
* `vta-webvh`: 0.2.8 -> 0.2.9

<details><summary><i><b>Changelog</b></i></summary><p>

## `vta-sdk`

<blockquote>

## [0.38.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-sdk-v0.37.0...vta-sdk-v0.38.0) — 2026-09-12

### Security

- **resolver**: Refuse did:webvh resolution to non-public hosts by default ([#1448](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1448))
</blockquote>



## `cnm-cli`

<blockquote>

## [0.15.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/cnm-cli-v0.14.4...cnm-cli-v0.15.0) — 2026-09-12

### Security

- **resolver**: Refuse did:webvh resolution to non-public hosts by default ([#1448](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1448))
</blockquote>




## `vta-service`

<blockquote>

## [0.27.0](https://github.com/OpenVTC/verifiable-trust-infrastructure/compare/vta-service-v0.26.0...vta-service-v0.27.0) — 2026-09-12

### Security

- **resolver**: Refuse did:webvh resolution to non-public hosts by default ([#1448](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1448))
</blockquote>













</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).