### PR TITLE
ci(release): let the newest push win the Release PR regeneration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -177,10 +177,13 @@ jobs:
 
   release-plz-pr:
     name: Release-plz PR
-    # Only on push. The Release PR tracks what has landed on main, so a
-    # recovery dispatch has nothing to tell it — regenerating it there would
-    # burn a run to produce the same PR.
-    if: github.event_name == 'push'
+    # Push, plus the recovery hatch. The Release PR tracks what has landed on
+    # main, so a dispatch usually regenerates the same PR for nothing — but
+    # "usually" is not "always": if this job is dropped (see the concurrency
+    # note below) the PR is left describing an older main, and a dispatch is
+    # then the cheapest way to bring it back in line without re-running a
+    # specific job by id.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -188,9 +191,25 @@ jobs:
       pull-requests: write
     concurrency:
       # Deliberately only on this job. Serialising the release job could skip a
-      # release; serialising PR updates just coalesces them.
+      # release; serialising PR updates is safe because the Release PR is a pure
+      # function of main's HEAD — regenerate it from the newest commit and the
+      # result is correct regardless of how many pushes were coalesced.
+      #
+      # `cancel-in-progress: true` precisely because of that. It used to be
+      # `false`, on the reasoning that serialising "just coalesces" the updates.
+      # It does not: GitHub keeps at most one *pending* run per group and drops
+      # the rest, so a burst of merges can discard the run for the newest commit
+      # and leave the older one to finish. That happened — four PRs merged
+      # within a few minutes and the surviving run produced a Release PR that
+      # was missing the last of them, with an empty changelog section for the
+      # crate that commit had changed. The PR still looked mergeable.
+      #
+      # With `true`, the newest push wins: an older in-flight regeneration is
+      # cancelled and loses nothing, because its output was already stale. The
+      # worst case is a cancelled force-push leaving the release branch
+      # half-updated, which the next push regenerates.
       group: release-plz-${{ github.ref }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## What happened

Four PRs merged within a few minutes — #1447, #1450, #1449, #1446. The `Release-plz PR` job for the last of them was **cancelled by its own concurrency group**:

| Job on `88668a41` | Result |
|---|---|
| `Release-plz release` | success (a no-op — every crate logged "Already published") |
| `Release-plz PR` | **cancelled** |

So #1452 was generated from an older main. It proposed a `vti-rooms` bump whose changelog section was **empty**, because the commit that actually changed `vti-rooms` (#1446, the chacha20poly1305 0.11 migration) was not in the tree it was generated from. The PR reported `MERGEABLE` and its checks passed — nothing about it looked wrong.

That entry is now permanently absent from `vti-rooms`' changelog: the tag sits after #1446's commit, so git-cliff will not pick it up in a later release either.

## Why the old setting was wrong

```yaml
# Serialising the release job could skip a release; serialising PR
# updates just coalesces them.
cancel-in-progress: false
```

The reasoning in that comment is the defect. `cancel-in-progress: false` does not coalesce — GitHub keeps at most **one pending run per group** and drops the rest, so a burst of merges can discard the run for the newest commit and let an older one run to completion.

## The change

`cancel-in-progress: true`, on this job only. That is right *specifically* because the Release PR is a pure function of main's HEAD — regenerating from the newest commit is correct however many pushes were coalesced, and cancelling an older in-flight run loses nothing, because its output was already stale.

The `release-plz-release` job still carries **no** concurrency group. Serialising that one could skip a release, which is why the group was only ever on the PR job; that reasoning was sound and is preserved in the comment.

Worst case under the new setting: a cancelled force-push leaves the release branch half-updated. The next push regenerates it, and the recovery hatch below covers the rest.

## Recovery hatch

The PR job now also runs on `workflow_dispatch`. The old comment was right that a dispatch usually regenerates the same PR for nothing — but when the job is dropped, the PR is left describing an older main, and a dispatch is a cheaper recovery than re-running a single job by id (which is what was needed this time).

## Verification

`.github/workflows/publish.yml` parses as YAML; asserted that `release-plz-pr` has `cancel-in-progress: true` and that `release-plz-release` still has no `concurrency` key. Nothing changes about what gets published or how the release job behaves.
